### PR TITLE
Fix Y-axis coordinate inversion for rendering and mouse input (fixes #6)

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -85,7 +85,7 @@ func (c *Canvas) startLoop() {
 	}
 	c.context.pressed = win.JustPressed
 	wincan := win.Canvas()
-	wincan.SetPixels(c.context.pix())
+	wincan.SetPixels(c.context.flippedPix())
 	win.Update()
 
 	ticker := time.NewTicker(time.Second / time.Duration(c.FrameRate))
@@ -94,11 +94,24 @@ func (c *Canvas) startLoop() {
 	for !win.Closed() {
 		c.context.IsMouseDragged = win.Pressed(pixel.MouseButtonLeft)
 		c.context.PMouse = c.context.Mouse
-		c.context.Mouse = win.MousePosition()
+		c.context.Mouse = toCanvasMousePos(win.MousePosition(), c.Height)
 		c.drawFunc()
-		wincan.SetPixels(c.context.pix())
+		wincan.SetPixels(c.context.flippedPix())
 		win.Update()
 		<-ticker.C
 	}
+}
+
+func flipV(src, dst []uint8, width, height int) {
+	stride := width * 4
+	for y := 0; y < height; y++ {
+		srcRow := src[y*stride : (y+1)*stride]
+		dstRow := dst[(height-1-y)*stride : (height-y)*stride]
+		copy(dstRow, srcRow)
+	}
+}
+
+func toCanvasMousePos(pixelPos pixel.Vec, height int) pixel.Vec {
+	return pixel.V(pixelPos.X, float64(height)-pixelPos.Y)
 }
 

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -110,3 +110,77 @@ func TestContext_Drawing(t *testing.T) {
 		t.Errorf("expected pixel to be red [255 0 0 255], got [%d %d %d %d]", pix[0], pix[1], pix[2], pix[3])
 	}
 }
+
+func TestFlipV(t *testing.T) {
+	// 2x2 image (4 pixels = 16 bytes)
+	// Row 0: Pixel 0: (1, 1, 1, 1), Pixel 1: (2, 2, 2, 2)
+	// Row 1: Pixel 2: (3, 3, 3, 3), Pixel 3: (4, 4, 4, 4)
+	src := []uint8{
+		1, 1, 1, 1, 2, 2, 2, 2,
+		3, 3, 3, 3, 4, 4, 4, 4,
+	}
+	dst := make([]uint8, len(src))
+	flipV(src, dst, 2, 2)
+
+	// After flip, Row 0 in dst should be Row 1 of src, and Row 1 in dst should be Row 0 of src
+	expected := []uint8{
+		3, 3, 3, 3, 4, 4, 4, 4,
+		1, 1, 1, 1, 2, 2, 2, 2,
+	}
+	for i, b := range dst {
+		if b != expected[i] {
+			t.Fatalf("at index %d: expected %d, got %d", i, expected[i], b)
+		}
+	}
+}
+
+func TestContext_FlippedPix(t *testing.T) {
+	// Draw a dot at top-left (0, 0)
+	ctx := NewContext(10, 10)
+	ctx.SetColor(color.Black)
+	ctx.Clear()
+	// Set (0,0) to Red
+	ctx.SetColor(color.RGBA{R: 255, G: 0, B: 0, A: 255})
+	ctx.SetPixel(0, 0)
+
+	// ctx.pix() (top-left origin) should have Red at pixel (0,0) which is index 0
+	pix := ctx.pix()
+	if pix[0] != 255 || pix[1] != 0 || pix[2] != 0 {
+		t.Fatalf("expected (0,0) in pix to be red, got [%d %d %d]", pix[0], pix[1], pix[2])
+	}
+
+	// In OpenGL texture space (bottom-left origin), the top-left pixel (0,0) in gg
+	// should end up at the top row in OpenGL, which is at the end of the flipped buffer:
+	// y = height - 1 = 9, x = 0 -> index = (9 * 10 + 0) * 4 = 360
+	flipped := ctx.flippedPix()
+	if flipped[360] != 255 || flipped[361] != 0 || flipped[362] != 0 {
+		t.Fatalf("expected top row in flippedPix to contain red at index 360, got [%d %d %d]", flipped[360], flipped[361], flipped[362])
+	}
+	// And bottom row in flippedPix (index 0) should be Black
+	if flipped[0] != 0 || flipped[1] != 0 || flipped[2] != 0 {
+		t.Fatalf("expected index 0 in flippedPix to be black, got [%d %d %d]", flipped[0], flipped[1], flipped[2])
+	}
+}
+
+func TestToCanvasMousePos(t *testing.T) {
+	height := 400
+
+	// OpenGL (0, 0) is bottom-left -> Processing canvas (0, height)
+	bottomLeft := toCanvasMousePos(pixel.V(0, 0), height)
+	if bottomLeft.X != 0 || bottomLeft.Y != 400 {
+		t.Errorf("expected bottom-left to be (0, 400), got (%v, %v)", bottomLeft.X, bottomLeft.Y)
+	}
+
+	// OpenGL (0, 400) is top-left -> Processing canvas (0, 0)
+	topLeft := toCanvasMousePos(pixel.V(0, 400), height)
+	if topLeft.X != 0 || topLeft.Y != 0 {
+		t.Errorf("expected top-left to be (0, 0), got (%v, %v)", topLeft.X, topLeft.Y)
+	}
+
+	// OpenGL center (300, 200) -> Processing canvas (300, 200)
+	center := toCanvasMousePos(pixel.V(300, 200), height)
+	if center.X != 300 || center.Y != 200 {
+		t.Errorf("expected center to be (300, 200), got (%v, %v)", center.X, center.Y)
+	}
+}
+

--- a/context.go
+++ b/context.go
@@ -11,27 +11,34 @@ import (
 
 type Context struct {
 	gg.Context
-	mu             sync.Mutex
-	IsMouseDragged bool
-	Mouse          pixel.Vec
-	PMouse         pixel.Vec
-	pressed        func(pixel.Button) bool
+	mu               sync.Mutex
+	IsMouseDragged   bool
+	Mouse            pixel.Vec
+	PMouse           pixel.Vec
+	pressed          func(pixel.Button) bool
+	flippedPixBuffer []uint8
 }
 
 func NewContext(width, height int) *Context {
 	var mu sync.Mutex
 	return &Context{
-		*gg.NewContext(width, height),
-		mu,
-		false,
-		pixel.Vec{X: 0, Y: 0},
-		pixel.Vec{X: 0, Y: 0},
-		func(pixel.Button) bool { return true },
+		Context:          *gg.NewContext(width, height),
+		mu:               mu,
+		IsMouseDragged:   false,
+		Mouse:            pixel.Vec{X: 0, Y: 0},
+		PMouse:           pixel.Vec{X: 0, Y: 0},
+		pressed:          func(pixel.Button) bool { return true },
+		flippedPixBuffer: make([]uint8, width*height*4),
 	}
 }
 
 func (ctx *Context) pix() []uint8 {
 	return ctx.Image().(*image.RGBA).Pix
+}
+
+func (ctx *Context) flippedPix() []uint8 {
+	flipV(ctx.pix(), ctx.flippedPixBuffer, ctx.Width(), ctx.Height())
+	return ctx.flippedPixBuffer
 }
 
 func (ctx *Context) IsKeyPressed(b pixel.Button) bool {


### PR DESCRIPTION
## Summary
Fixes #6.

This PR fixes the vertical coordinate system mismatch between `gg` (top-left origin, Y downwards / Processing-like standard) and `pixel`/OpenGL (bottom-left origin, Y upwards).

### Changes
1. **Vertical Flip for Framebuffer Transfer (`flipV`)**:
   - `Context.flippedPix()` vertically flips the CPU raster image before passing it to Pixel's window canvas.
   - Pre-allocates a buffer in `Context` to avoid per-frame allocations during main loop execution.
   - Fixes upside-down/mirrored text rendering and aligns rendered output with Processing / HTML Canvas conventions.
2. **Top-Left Mouse Coordinates (`toCanvasMousePos`)**:
   - Transforms `win.MousePosition()` ($Y=0$ at bottom) to canvas coordinates ($Y=0$ at top).
3. **Unit Tests (TDD)**:
   - Added tests for `flipV`, `Context.flippedPix()`, and `toCanvasMousePos` in `canvas_test.go`.