### PR TITLE
Creative coding enhancements: Perlin noise, default font, style helpers, and save frame (fixes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Check the [examples](examples) directory for complete programs:
 
 - [`drawline`](examples/drawline): Interactive mouse drawing and key interactions.
 - [`lifegame`](examples/lifegame): Conway's Game of Life simulation.
+- [`noise-landscape`](examples/noise-landscape): Organic wave animation with Perlin noise.
 - [`rotate-objects`](examples/rotate-objects): Coordinate system rotation and object transformations.
 - [`text`](examples/text): Text rendering, time tracking, and frame rate display.
 

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -240,4 +240,53 @@ func TestContext_InputAndFrameState(t *testing.T) {
 	}
 }
 
+func TestContext_DefaultFont(t *testing.T) {
+	ctx := NewContext(100, 100)
+	// Should not panic when drawing text without explicitly setting a font face
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("drawing text with default font panicked: %v", r)
+		}
+	}()
+	ctx.SetColor(color.White)
+	ctx.DrawString("Hello", 10, 20)
+}
+
+func TestContext_StyleHelpers(t *testing.T) {
+	ctx := NewContext(50, 50)
+
+	// FillHex
+	ctx.FillHex("#ff0000")
+	ctx.DrawRectangle(0, 0, 50, 50)
+	ctx.Fill()
+	pix := ctx.pix()
+	if pix[0] != 255 || pix[1] != 0 || pix[2] != 0 {
+		t.Errorf("expected FillHex to set fill color to red, got [%d %d %d]", pix[0], pix[1], pix[2])
+	}
+
+	// StrokeRGB & FillRGB
+	ctx.FillRGB(0, 1, 0)
+	ctx.StrokeRGB(0, 0, 1)
+
+	// FillRGBA & StrokeRGBA
+	ctx.FillRGBA(1, 1, 0, 0.5)
+	ctx.StrokeRGBA(0, 1, 1, 0.8)
+
+	// NoFill & NoStroke (transparent)
+	ctx.NoFill()
+	ctx.NoStroke()
+}
+
+func TestContext_SaveFrame(t *testing.T) {
+	ctx := NewContext(10, 10)
+	ctx.BackgroundRGB(1, 0, 0)
+
+	tmpFile := t.TempDir() + "/test_frame.png"
+	err := ctx.SaveFrame(tmpFile)
+	if err != nil {
+		t.Fatalf("SaveFrame failed: %v", err)
+	}
+}
+
+
 

--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/fogleman/gg"
+	"golang.org/x/image/font/basicfont"
 )
 
 type Context struct {
@@ -26,7 +27,7 @@ type Context struct {
 
 func NewContext(width, height int) *Context {
 	var mu sync.Mutex
-	return &Context{
+	ctx := &Context{
 		Context:          *gg.NewContext(width, height),
 		mu:               mu,
 		IsMouseDragged:   false,
@@ -37,6 +38,8 @@ func NewContext(width, height int) *Context {
 		justReleased:     func(Key) bool { return false },
 		flippedPixBuffer: make([]uint8, width*height*4),
 	}
+	ctx.SetFontFace(basicfont.Face7x13)
+	return ctx
 }
 
 func (ctx *Context) pix() []uint8 {
@@ -80,6 +83,61 @@ func (ctx *Context) BackgroundHex(hex string) {
 	ctx.Pop()
 }
 
+// FillColor sets the current drawing color.
+func (ctx *Context) FillColor(c color.Color) {
+	ctx.SetColor(c)
+}
+
+// StrokeColor sets the current drawing color.
+func (ctx *Context) StrokeColor(c color.Color) {
+	ctx.SetColor(c)
+}
+
+// FillRGB sets the drawing color with RGB values (0.0 to 1.0).
+func (ctx *Context) FillRGB(r, g, b float64) {
+	ctx.SetRGB(r, g, b)
+}
+
+// StrokeRGB sets the drawing color with RGB values (0.0 to 1.0).
+func (ctx *Context) StrokeRGB(r, g, b float64) {
+	ctx.SetRGB(r, g, b)
+}
+
+// FillRGBA sets the drawing color with RGBA values (0.0 to 1.0).
+func (ctx *Context) FillRGBA(r, g, b, a float64) {
+	ctx.SetRGBA(r, g, b, a)
+}
+
+// StrokeRGBA sets the drawing color with RGBA values (0.0 to 1.0).
+func (ctx *Context) StrokeRGBA(r, g, b, a float64) {
+	ctx.SetRGBA(r, g, b, a)
+}
+
+// FillHex sets the drawing color with a hexadecimal string (e.g., "#ff0000").
+func (ctx *Context) FillHex(hex string) {
+	ctx.SetHexColor(hex)
+}
+
+// StrokeHex sets the drawing color with a hexadecimal string (e.g., "#ff0000").
+func (ctx *Context) StrokeHex(hex string) {
+	ctx.SetHexColor(hex)
+}
+
+// NoFill sets the fill color to transparent.
+func (ctx *Context) NoFill() {
+	ctx.SetColor(color.Transparent)
+}
+
+// NoStroke sets the stroke color to transparent.
+func (ctx *Context) NoStroke() {
+	ctx.SetColor(color.Transparent)
+}
+
+// SaveFrame saves the current context buffer as a PNG image to the given path.
+func (ctx *Context) SaveFrame(path string) error {
+	return ctx.SavePNG(path)
+}
+
 // IsKeyPressed returns true if the key was just pressed in the current frame.
 func (ctx *Context) IsKeyPressed(k Key) bool {
 	return ctx.justPressed(k)
@@ -109,5 +167,6 @@ func (ctx *Context) IsMouseJustPressed(btn MouseButton) bool {
 func (ctx *Context) IsMouseJustReleased(btn MouseButton) bool {
 	return ctx.justReleased(btn)
 }
+
 
 

--- a/examples/noise-landscape/main.go
+++ b/examples/noise-landscape/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/h8gi/canvas"
+	"golang.org/x/image/colornames"
+)
+
+func main() {
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     640,
+		Height:    400,
+		FrameRate: 60,
+		Title:     "Perlin Noise Wave Animation",
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		ctx.BackgroundHex("#0f172a")
+
+		// Draw multiple undulating noise waves
+		numWaves := 6
+		for w := 0; w < numWaves; w++ {
+			baseY := float64(ctx.Height())*0.4 + float64(w)*35
+			colorAlpha := 0.25 + float64(w)*0.12
+
+			ctx.FillRGBA(0.2, 0.6+float64(w)*0.06, 0.9, colorAlpha)
+			ctx.StrokeHex("#38bdf8")
+			ctx.SetLineWidth(1.5)
+
+			ctx.MoveTo(0, float64(ctx.Height()))
+			ctx.LineTo(0, baseY)
+
+			step := 8.0
+			for x := 0.0; x <= float64(ctx.Width()); x += step {
+				// Perlin noise calculation with time offset
+				n := canvas.Noise(x*0.005+float64(w)*0.8, ctx.Time*0.4+float64(w)*0.2, float64(w))
+				yOffset := (n - 0.5) * 90.0
+				ctx.LineTo(x, baseY+yOffset)
+			}
+
+			ctx.LineTo(float64(ctx.Width()), float64(ctx.Height()))
+			ctx.ClosePath()
+			ctx.Fill()
+		}
+
+		// Text info using built-in default font
+		ctx.FillColor(colornames.White)
+		ctx.DrawStringAnchored("Perlin Noise Wave Animation", 20, 30, 0, 0.5)
+
+		info := fmt.Sprintf("Frame: %d | Time: %.2fs", ctx.FrameCount, ctx.Time)
+		ctx.FillHex("#94a3b8")
+		ctx.DrawStringAnchored(info, 20, 50, 0, 0.5)
+	})
+}

--- a/noise.go
+++ b/noise.go
@@ -1,0 +1,126 @@
+package canvas
+
+import (
+	"math"
+	"math/rand"
+)
+
+var defaultPerm = []int{
+	151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142,
+	8, 99, 37, 240, 21, 10, 23, 190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117,
+	35, 11, 32, 57, 177, 33, 88, 237, 149, 56, 87, 174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71,
+	134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211, 133, 230, 220, 105, 92, 41,
+	55, 46, 245, 40, 244, 102, 143, 54, 65, 25, 63, 161, 1, 216, 80, 73, 209, 76, 132, 187, 208, 89,
+	18, 169, 200, 196, 135, 130, 116, 188, 159, 86, 164, 100, 109, 198, 173, 186, 3, 64, 52, 217, 226,
+	250, 124, 123, 5, 202, 38, 147, 118, 126, 255, 82, 85, 212, 207, 206, 59, 227, 47, 16, 58, 17, 182,
+	189, 28, 42, 223, 183, 170, 213, 119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101, 155, 167, 43,
+	172, 9, 129, 22, 39, 253, 19, 98, 108, 110, 79, 113, 224, 232, 178, 185, 112, 104, 218, 246, 97,
+	228, 251, 34, 242, 193, 238, 210, 144, 12, 191, 179, 162, 241, 81, 51, 145, 235, 249, 14, 239,
+	107, 49, 192, 214, 31, 181, 199, 106, 157, 184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254,
+	138, 236, 205, 93, 222, 114, 67, 29, 24, 72, 243, 141, 128, 195, 78, 66, 215, 61, 156, 180,
+}
+
+var p = initPerm(defaultPerm)
+
+func initPerm(src []int) []int {
+	perm := make([]int, 512)
+	for i := 0; i < 256; i++ {
+		perm[i] = src[i]
+		perm[256+i] = src[i]
+	}
+	return perm
+}
+
+// NoiseSeed sets the seed value for the Noise generation.
+func NoiseSeed(seed int64) {
+	r := rand.New(rand.NewSource(seed))
+	shuffled := make([]int, 256)
+	for i := 0; i < 256; i++ {
+		shuffled[i] = i
+	}
+	r.Shuffle(256, func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	p = initPerm(shuffled)
+}
+
+func fade(t float64) float64 {
+	return t * t * t * (t*(t*6-15) + 10)
+}
+
+func grad(hash int, x, y, z float64) float64 {
+	h := hash & 15
+	u := x
+	if h >= 8 {
+		u = y
+	}
+	v := y
+	if h >= 4 {
+		if h == 12 || h == 14 {
+			v = x
+		} else {
+			v = z
+		}
+	}
+	var res float64
+	if (h & 1) == 0 {
+		res += u
+	} else {
+		res -= u
+	}
+	if (h & 2) == 0 {
+		res += v
+	} else {
+		res -= v
+	}
+	return res
+}
+
+// Noise returns the 3D Perlin noise value at (x, y, z) scaled to [0.0, 1.0].
+func Noise(x, y, z float64) float64 {
+	X := int(math.Floor(x)) & 255
+	Y := int(math.Floor(y)) & 255
+	Z := int(math.Floor(z)) & 255
+
+	x -= math.Floor(x)
+	y -= math.Floor(y)
+	z -= math.Floor(z)
+
+	u := fade(x)
+	v := fade(y)
+	w := fade(z)
+
+	A := p[X] + Y
+	AA := p[A] + Z
+	AB := p[A+1] + Z
+	B := p[X+1] + Y
+	BA := p[B] + Z
+	BB := p[B+1] + Z
+
+	val := Lerp(
+		Lerp(
+			Lerp(grad(p[AA], x, y, z), grad(p[BA], x-1, y, z), u),
+			Lerp(grad(p[AB], x, y-1, z), grad(p[BB], x-1, y-1, z), u),
+			v,
+		),
+		Lerp(
+			Lerp(grad(p[AA+1], x, y, z-1), grad(p[BA+1], x-1, y, z-1), u),
+			Lerp(grad(p[AB+1], x, y-1, z-1), grad(p[BB+1], x-1, y-1, z-1), u),
+			v,
+		),
+		w,
+	)
+
+	// Map from [-1.0, 1.0] to [0.0, 1.0]
+	return Constrain((val+1.0)/2.0, 0.0, 1.0)
+}
+
+// Noise2D returns the 2D Perlin noise value at (x, y) scaled to [0.0, 1.0].
+func Noise2D(x, y float64) float64 {
+	return Noise(x, y, 0)
+}
+
+// Noise1D returns the 1D Perlin noise value at x scaled to [0.0, 1.0].
+func Noise1D(x float64) float64 {
+	return Noise(x, 0, 0)
+}

--- a/noise_test.go
+++ b/noise_test.go
@@ -1,0 +1,60 @@
+package canvas
+
+import (
+	"math"
+	"testing"
+)
+
+func TestNoise(t *testing.T) {
+	t.Run("Range [0.0, 1.0]", func(t *testing.T) {
+		for x := -5.0; x <= 5.0; x += 0.3 {
+			for y := -5.0; y <= 5.0; y += 0.3 {
+				val := Noise2D(x, y)
+				if val < 0.0 || val > 1.0 {
+					t.Fatalf("Noise2D(%v, %v) = %v is out of [0.0, 1.0] range", x, y, val)
+				}
+			}
+		}
+	})
+
+	t.Run("Continuity", func(t *testing.T) {
+		x := 1.234
+		y := 5.678
+		delta := 0.001
+		v1 := Noise2D(x, y)
+		v2 := Noise2D(x+delta, y)
+		diff := math.Abs(v1 - v2)
+		if diff > 0.05 {
+			t.Errorf("Noise lacks continuity: v1=%v, v2=%v, diff=%v", v1, v2, diff)
+		}
+	})
+
+	t.Run("1D and 3D shortcuts", func(t *testing.T) {
+		v1D := Noise1D(2.5)
+		if v1D < 0.0 || v1D > 1.0 {
+			t.Errorf("Noise1D out of range: %v", v1D)
+		}
+		v3D := Noise(1.0, 2.0, 3.0)
+		if v3D < 0.0 || v3D > 1.0 {
+			t.Errorf("Noise (3D) out of range: %v", v3D)
+		}
+	})
+
+	t.Run("Seed reproducibility", func(t *testing.T) {
+		NoiseSeed(42)
+		val1 := Noise2D(3.14, 2.71)
+
+		NoiseSeed(42)
+		val2 := Noise2D(3.14, 2.71)
+
+		if val1 != val2 {
+			t.Errorf("Expected same noise output for seed 42, got %v and %v", val1, val2)
+		}
+
+		NoiseSeed(999)
+		val3 := Noise2D(3.14, 2.71)
+		if val1 == val3 {
+			t.Errorf("Expected different noise output for different seeds, both were %v", val1)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes #9.

This PR adds essential creative coding features inspired by Processing to make generative sketches and animations expressive and convenient.

### Key Changes
1. **Perlin Noise (`noise.go`)**:
   - Pure Go implementation of Ken Perlin's Improved Noise.
   - `canvas.Noise(x, y, z)`, `canvas.Noise2D(x, y)`, `canvas.Noise1D(x)`, `canvas.NoiseSeed(seed)`.
   - Scaled to `[0.0, 1.0]` range for Processing-like consistency.
2. **Default Font Initialization (`context.go`)**:
   - Pre-sets `basicfont.Face7x13` in `NewContext` so `ctx.DrawString` works out of the box without font file loading.
3. **Style & Color Helpers (`context.go`)**:
   - `ctx.FillHex`, `ctx.StrokeHex`, `ctx.FillRGB`, `ctx.StrokeRGB`, `ctx.FillRGBA`, `ctx.StrokeRGBA`.
   - `ctx.NoFill()`, `ctx.NoStroke()`.
4. **Frame Capture (`context.go`)**:
   - `ctx.SaveFrame(path)`: Export current frame as a PNG image.
5. **New Example & Tests**:
   - Added `examples/noise-landscape`: Multi-layered Perlin noise wave animation.
   - Unit tests in `noise_test.go` and `canvas_test.go`.