### PR TITLE
Window and loop control: noLoop/loop/redraw and window configuration options (fixes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Check the [examples](examples) directory for complete programs:
 - [`lifegame`](examples/lifegame): Conway's Game of Life simulation.
 - [`noise-landscape`](examples/noise-landscape): Organic wave animation with Perlin noise.
 - [`rotate-objects`](examples/rotate-objects): Coordinate system rotation and object transformations.
+- [`static-art`](examples/static-art): Single-frame generative art using `NoLoop()`.
 - [`text`](examples/text): Text rendering, time tracking, and frame rate display.
 
 ## Built With

--- a/canvas.go
+++ b/canvas.go
@@ -2,6 +2,7 @@
 package canvas
 
 import (
+	"sync"
 	"time"
 
 	"github.com/gopxl/pixel/v2"
@@ -10,23 +11,32 @@ import (
 
 // drawing area
 type Canvas struct {
-	Width     int
-	Height    int
-	FrameRate int
-	title     string
-	initFunc  func()
-	drawFunc  func()
-	context   *Context
+	Width      int
+	Height     int
+	FrameRate  int
+	title      string
+	resizable  bool
+	fullscreen bool
+	looping    bool
+	redrawReq  bool
+	initFunc   func()
+	drawFunc   func()
+	context    *Context
+	mu         sync.Mutex
 }
 
 type CanvasConfig struct {
 	Width, Height, FrameRate int
 	Title                    string
+	Resizable                bool
+	Fullscreen               bool
 }
 
 func NewCanvas(opts *CanvasConfig) *Canvas {
 	width, height, frameRate := 600, 400, 60
 	title := "canvas"
+	resizable := false
+	fullscreen := false
 
 	if opts != nil {
 		if opts.Width > 0 {
@@ -39,18 +49,51 @@ func NewCanvas(opts *CanvasConfig) *Canvas {
 			frameRate = opts.FrameRate
 		}
 		title = opts.Title
+		resizable = opts.Resizable
+		fullscreen = opts.Fullscreen
 	}
 
 	c := &Canvas{
-		Width:     width,
-		Height:    height,
-		FrameRate: frameRate,
-		title:     title,
+		Width:      width,
+		Height:     height,
+		FrameRate:  frameRate,
+		title:      title,
+		resizable:  resizable,
+		fullscreen: fullscreen,
+		looping:    true,
 	}
 	c.context = NewContext(width, height)
 	// set init drawer
 	c.Setup(func(*Context) {})
 	return c
+}
+
+// NoLoop stops the continuous animation loop.
+func (c *Canvas) NoLoop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.looping = false
+}
+
+// Loop resumes the continuous animation loop.
+func (c *Canvas) Loop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.looping = true
+}
+
+// Redraw requests a single frame draw when the loop is paused.
+func (c *Canvas) Redraw() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.redrawReq = true
+}
+
+// IsLooping returns true if the animation loop is currently active.
+func (c *Canvas) IsLooping() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.looping
 }
 
 // initialize drawer
@@ -75,10 +118,15 @@ func (c *Canvas) Draw(drawer func(*Context)) {
 
 func (c *Canvas) startLoop() {
 	cfg := opengl.WindowConfig{
-		Title:  c.title,
-		Bounds: pixel.R(0, 0, float64(c.Width), float64(c.Height)),
-		VSync:  true,
+		Title:     c.title,
+		Bounds:    pixel.R(0, 0, float64(c.Width), float64(c.Height)),
+		VSync:     true,
+		Resizable: c.resizable,
 	}
+	if c.fullscreen {
+		cfg.Monitor = opengl.PrimaryMonitor()
+	}
+
 	win, err := opengl.NewWindow(cfg)
 	if err != nil {
 		panic(err)
@@ -102,13 +150,22 @@ func (c *Canvas) startLoop() {
 		c.context.DeltaTime = now.Sub(lastTime).Seconds()
 		c.context.Time = now.Sub(startTime).Seconds()
 		lastTime = now
-		c.context.FrameCount++
 
 		c.context.IsMouseDragged = win.Pressed(pixel.MouseButtonLeft)
 		c.context.PMouse = c.context.Mouse
 		c.context.Mouse = toCanvasMousePos(win.MousePosition(), c.Height)
-		c.drawFunc()
-		wincan.SetPixels(c.context.flippedPix())
+
+		c.mu.Lock()
+		shouldDraw := c.looping || c.redrawReq
+		c.redrawReq = false
+		c.mu.Unlock()
+
+		if shouldDraw {
+			c.context.FrameCount++
+			c.drawFunc()
+			wincan.SetPixels(c.context.flippedPix())
+		}
+
 		win.Update()
 		<-ticker.C
 	}

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -288,5 +288,47 @@ func TestContext_SaveFrame(t *testing.T) {
 	}
 }
 
+func TestCanvas_LoopControl(t *testing.T) {
+	c := NewCanvas(nil)
+	if !c.IsLooping() {
+		t.Error("expected canvas to be looping by default")
+	}
+
+	c.NoLoop()
+	if c.IsLooping() {
+		t.Error("expected canvas not to be looping after NoLoop()")
+	}
+
+	c.Loop()
+	if !c.IsLooping() {
+		t.Error("expected canvas to be looping after Loop()")
+	}
+
+	c.NoLoop()
+	c.Redraw()
+	if !c.redrawReq {
+		t.Error("expected redrawReq to be true after Redraw()")
+	}
+}
+
+func TestCanvas_ConfigOptions(t *testing.T) {
+	cfg := &CanvasConfig{
+		Width:      800,
+		Height:     600,
+		FrameRate:  60,
+		Title:      "Extended Config",
+		Resizable:  true,
+		Fullscreen: true,
+	}
+	c := NewCanvas(cfg)
+	if !c.resizable {
+		t.Error("expected resizable to be true")
+	}
+	if !c.fullscreen {
+		t.Error("expected fullscreen to be true")
+	}
+}
+
+
 
 

--- a/examples/static-art/main.go
+++ b/examples/static-art/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"math/rand"
+
+	"github.com/h8gi/canvas"
+	"golang.org/x/image/colornames"
+)
+
+func main() {
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     640,
+		Height:    400,
+		FrameRate: 30,
+		Title:     "Static Generative Art (NoLoop Example)",
+		Resizable: true,
+	})
+
+	c.Setup(func(ctx *canvas.Context) {
+		// Stop continuous frame rendering after the first frame
+		c.NoLoop()
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		ctx.BackgroundHex("#181825")
+
+		// Draw generative geometric circles
+		for i := 0; i < 40; i++ {
+			x := canvas.Random(50, float64(ctx.Width())-50)
+			y := canvas.Random(50, float64(ctx.Height())-50)
+			radius := canvas.Random(10, 60)
+
+			ctx.FillRGBA(rand.Float64(), rand.Float64(), rand.Float64(), 0.6)
+			ctx.StrokeHex("#cdd6f4")
+			ctx.SetLineWidth(1.5)
+			ctx.DrawCircle(x, y, radius)
+			ctx.Fill()
+			ctx.Stroke()
+		}
+
+		// Instructions
+		ctx.FillColor(colornames.White)
+		ctx.DrawStringAnchored("Generative Static Art (Rendered once with NoLoop)", float64(ctx.Width())/2, 370, 0.5, 0.5)
+	})
+}


### PR DESCRIPTION
## Summary
Fixes #10.

This PR adds render loop controls and window configuration options for static art, event-driven sketches, and varied display setups.

### Key Changes
1. **Loop Controls (`canvas.go`)**:
   - `c.NoLoop()`: Pause continuous frame updates to save CPU for static artwork or custom triggers.
   - `c.Loop()`: Resume the continuous animation loop.
   - `c.Redraw()`: Trigger a single frame draw when paused.
   - `c.IsLooping() bool`: Check current looping state.
2. **Window Config Options (`canvas.go`)**:
   - `CanvasConfig.Resizable bool`: Allow window resizing.
   - `CanvasConfig.Fullscreen bool`: Launch in fullscreen on the primary monitor.
3. **New Example & Tests**:
   - Added `examples/static-art`: Demonstrates single-frame rendering with `NoLoop()`.
   - Unit tests in `canvas_test.go`.