### PR TITLE
Add concise README.md for each example

### DIFF
--- a/examples/drawline/README.md
+++ b/examples/drawline/README.md
@@ -1,0 +1,15 @@
+# Draw Line Example
+
+An interactive sketch demonstrating real-time mouse drawing and keyboard interaction.
+
+## How to Run
+
+```sh
+go run main.go
+```
+
+## Controls
+
+- **Mouse Drag (Left Click)**: Draw red lines.
+- **Mouse Move**: Draw continuous green lines.
+- **UP Arrow Key**: Clear the canvas with a white background.

--- a/examples/lifegame/README.md
+++ b/examples/lifegame/README.md
@@ -1,0 +1,13 @@
+# Life Game Example
+
+Conway's Game of Life cellular automaton simulation built with `canvas`.
+
+## How to Run
+
+```sh
+go run main.go
+```
+
+## Controls
+
+- **S Key**: Toggle pause/resume the simulation.

--- a/examples/noise-landscape/README.md
+++ b/examples/noise-landscape/README.md
@@ -1,0 +1,9 @@
+# Perlin Noise Wave Animation Example
+
+A generative organic landscape demonstrating the built-in 3D Perlin noise generator (`canvas.Noise`).
+
+## How to Run
+
+```sh
+go run main.go
+```

--- a/examples/rotate-objects/README.md
+++ b/examples/rotate-objects/README.md
@@ -1,0 +1,9 @@
+# Rotate Objects Example
+
+Demonstrates affine transformations, rotation around specific anchor points (`RotateAbout`), and matrix state stacking with `Push()` and `Pop()`.
+
+## How to Run
+
+```sh
+go run main.go
+```

--- a/examples/static-art/README.md
+++ b/examples/static-art/README.md
@@ -1,0 +1,11 @@
+# Static Generative Art Example
+
+Demonstrates rendering static generative art using `c.NoLoop()`.
+
+The artwork renders once on launch and pauses continuous frame updates to keep CPU usage at near zero.
+
+## How to Run
+
+```sh
+go run main.go
+```

--- a/examples/text/README.md
+++ b/examples/text/README.md
@@ -1,0 +1,13 @@
+# Text and Typography Example
+
+Demonstrates out-of-the-box text rendering, live animation stats (`FrameCount`, `DeltaTime`, `Time`), and mouse interaction.
+
+## How to Run
+
+```sh
+go run main.go
+```
+
+## Controls
+
+- **Mouse Move / Drag**: Move the interactive cursor and update mouse coordinates in real time.


### PR DESCRIPTION
## Summary
Adds lightweight, helpful `README.md` files to all example projects in `examples/`:
- `drawline`: Interactive mouse line sketch and UP arrow clear key.
- `lifegame`: Conway's Game of Life simulation with `S` key pause.
- `noise-landscape`: Multi-layered 3D Perlin noise wave animation.
- `rotate-objects`: Affine matrix transformations and `RotateAbout`.
- `static-art`: Single-frame generative grid art using `NoLoop()`.
- `text`: Typography, stats, and real-time mouse interaction.