### PR TITLE
Add HSB/HSL color utilities, Hex/RGB helpers, and LerpColor

### DIFF
--- a/color.go
+++ b/color.go
@@ -1,0 +1,144 @@
+package canvas
+
+import (
+	"fmt"
+	"image/color"
+	"math"
+	"strings"
+)
+
+// RGB creates a new color.RGBA with the given red, green, blue values (0-255) and full opacity (255).
+func RGB(r, g, b uint8) color.RGBA {
+	return color.RGBA{R: r, G: g, B: b, A: 255}
+}
+
+// RGBA creates a new color.RGBA with the given red, green, blue, and alpha values (0-255).
+func RGBA(r, g, b, a uint8) color.RGBA {
+	return color.RGBA{R: r, G: g, B: b, A: a}
+}
+
+// Hex parses a hexadecimal color string (e.g. "#ff0055", "#fff", "38bdf8") and returns color.RGBA.
+func Hex(hex string) color.RGBA {
+	hex = strings.TrimPrefix(hex, "#")
+	var r, g, b, a uint8 = 0, 0, 0, 255
+	switch len(hex) {
+	case 3: // RGB (e.g. "fff")
+		fmt.Sscanf(hex, "%1x%1x%1x", &r, &g, &b)
+		r = (r << 4) | r
+		g = (g << 4) | g
+		b = (b << 4) | b
+	case 4: // RGBA (e.g. "ffff")
+		fmt.Sscanf(hex, "%1x%1x%1x%1x", &r, &g, &b, &a)
+		r = (r << 4) | r
+		g = (g << 4) | g
+		b = (b << 4) | b
+		a = (a << 4) | a
+	case 6: // RRGGBB (e.g. "ffffff")
+		fmt.Sscanf(hex, "%02x%02x%02x", &r, &g, &b)
+	case 8: // RRGGBBAA (e.g. "ffffffff")
+		fmt.Sscanf(hex, "%02x%02x%02x%02x", &r, &g, &b, &a)
+	}
+	return color.RGBA{R: r, G: g, B: b, A: a}
+}
+
+// HSB converts Hue (0-360), Saturation (0-1), and Brightness (0-1) to color.RGBA with full alpha.
+func HSB(h, s, b float64) color.RGBA {
+	return HSBA(h, s, b, 1.0)
+}
+
+// HSBA converts Hue (0-360), Saturation (0-1), Brightness (0-1), and Alpha (0-1) to color.RGBA.
+func HSBA(h, s, b, a float64) color.RGBA {
+	h = math.Mod(h, 360.0)
+	if h < 0 {
+		h += 360.0
+	}
+	s = Constrain(s, 0.0, 1.0)
+	b = Constrain(b, 0.0, 1.0)
+	a = Constrain(a, 0.0, 1.0)
+
+	c := b * s
+	x := c * (1.0 - math.Abs(math.Mod(h/60.0, 2.0)-1.0))
+	m := b - c
+
+	var rPrime, gPrime, bPrime float64
+	switch {
+	case h < 60:
+		rPrime, gPrime, bPrime = c, x, 0
+	case h < 120:
+		rPrime, gPrime, bPrime = x, c, 0
+	case h < 180:
+		rPrime, gPrime, bPrime = 0, c, x
+	case h < 240:
+		rPrime, gPrime, bPrime = 0, x, c
+	case h < 300:
+		rPrime, gPrime, bPrime = x, 0, c
+	default:
+		rPrime, gPrime, bPrime = c, 0, x
+	}
+
+	return color.RGBA{
+		R: uint8(math.Round((rPrime + m) * 255.0)),
+		G: uint8(math.Round((gPrime + m) * 255.0)),
+		B: uint8(math.Round((bPrime + m) * 255.0)),
+		A: uint8(math.Round(a * 255.0)),
+	}
+}
+
+// HSL converts Hue (0-360), Saturation (0-1), and Lightness (0-1) to color.RGBA with full alpha.
+func HSL(h, s, l float64) color.RGBA {
+	return HSLA(h, s, l, 1.0)
+}
+
+// HSLA converts Hue (0-360), Saturation (0-1), Lightness (0-1), and Alpha (0-1) to color.RGBA.
+func HSLA(h, s, l, a float64) color.RGBA {
+	h = math.Mod(h, 360.0)
+	if h < 0 {
+		h += 360.0
+	}
+	s = Constrain(s, 0.0, 1.0)
+	l = Constrain(l, 0.0, 1.0)
+	a = Constrain(a, 0.0, 1.0)
+
+	c := (1.0 - math.Abs(2.0*l-1.0)) * s
+	x := c * (1.0 - math.Abs(math.Mod(h/60.0, 2.0)-1.0))
+	m := l - c/2.0
+
+	var rPrime, gPrime, bPrime float64
+	switch {
+	case h < 60:
+		rPrime, gPrime, bPrime = c, x, 0
+	case h < 120:
+		rPrime, gPrime, bPrime = x, c, 0
+	case h < 180:
+		rPrime, gPrime, bPrime = 0, c, x
+	case h < 240:
+		rPrime, gPrime, bPrime = 0, x, c
+	case h < 300:
+		rPrime, gPrime, bPrime = x, 0, c
+	default:
+		rPrime, gPrime, bPrime = c, 0, x
+	}
+
+	return color.RGBA{
+		R: uint8(math.Round((rPrime + m) * 255.0)),
+		G: uint8(math.Round((gPrime + m) * 255.0)),
+		B: uint8(math.Round((bPrime + m) * 255.0)),
+		A: uint8(math.Round(a * 255.0)),
+	}
+}
+
+// LerpColor calculates a color between two colors at a specific increment (amt between 0.0 and 1.0).
+func LerpColor(c1, c2 color.Color, amt float64) color.RGBA {
+	amt = Constrain(amt, 0.0, 1.0)
+
+	r1, g1, b1, a1 := c1.RGBA()
+	r2, g2, b2, a2 := c2.RGBA()
+
+	// RGBA() returns alpha-premultiplied uint32 in range [0, 65535]
+	r := uint8(math.Round((float64(r1>>8) + amt*(float64(r2>>8)-float64(r1>>8)))))
+	g := uint8(math.Round((float64(g1>>8) + amt*(float64(g2>>8)-float64(g1>>8)))))
+	b := uint8(math.Round((float64(b1>>8) + amt*(float64(b2>>8)-float64(b1>>8)))))
+	a := uint8(math.Round((float64(a1>>8) + amt*(float64(a2>>8)-float64(a1>>8)))))
+
+	return color.RGBA{R: r, G: g, B: b, A: a}
+}

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,106 @@
+package canvas
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestColorUtilities(t *testing.T) {
+	t.Run("RGB and RGBA", func(t *testing.T) {
+		c1 := RGB(255, 128, 0)
+		if c1.R != 255 || c1.G != 128 || c1.B != 0 || c1.A != 255 {
+			t.Errorf("unexpected RGB result: %+v", c1)
+		}
+
+		c2 := RGBA(10, 20, 30, 40)
+		if c2.R != 10 || c2.G != 20 || c2.B != 30 || c2.A != 40 {
+			t.Errorf("unexpected RGBA result: %+v", c2)
+		}
+	})
+
+	t.Run("Hex", func(t *testing.T) {
+		cRed := Hex("#ff0000")
+		if cRed.R != 255 || cRed.G != 0 || cRed.B != 0 || cRed.A != 255 {
+			t.Errorf("Hex(#ff0000) expected red, got %+v", cRed)
+		}
+
+		cShort := Hex("#0f0")
+		if cShort.R != 0 || cShort.G != 255 || cShort.B != 0 || cShort.A != 255 {
+			t.Errorf("Hex(#0f0) expected green, got %+v", cShort)
+		}
+	})
+
+	t.Run("HSB to RGBA", func(t *testing.T) {
+		// Red: H=0, S=1, B=1
+		red := HSB(0, 1, 1)
+		if red.R != 255 || red.G != 0 || red.B != 0 || red.A != 255 {
+			t.Errorf("HSB(0, 1, 1) expected red [255 0 0 255], got %+v", red)
+		}
+
+		// Green: H=120, S=1, B=1
+		green := HSB(120, 1, 1)
+		if green.R != 0 || green.G != 255 || green.B != 0 || green.A != 255 {
+			t.Errorf("HSB(120, 1, 1) expected green [0 255 0 255], got %+v", green)
+		}
+
+		// Blue: H=240, S=1, B=1
+		blue := HSB(240, 1, 1)
+		if blue.R != 0 || blue.G != 0 || blue.B != 255 || blue.A != 255 {
+			t.Errorf("HSB(240, 1, 1) expected blue [0 0 255 255], got %+v", blue)
+		}
+
+		// White: H=0, S=0, B=1
+		white := HSB(0, 0, 1)
+		if white.R != 255 || white.G != 255 || white.B != 255 || white.A != 255 {
+			t.Errorf("HSB(0, 0, 1) expected white, got %+v", white)
+		}
+
+		// Alpha support
+		semiRed := HSBA(0, 1, 1, 0.5)
+		if semiRed.R != 255 || semiRed.A != 128 && semiRed.A != 127 {
+			t.Errorf("HSBA alpha expected ~128, got %d", semiRed.A)
+		}
+	})
+
+	t.Run("HSL to RGBA", func(t *testing.T) {
+		red := HSL(0, 1, 0.5)
+		if red.R != 255 || red.G != 0 || red.B != 0 || red.A != 255 {
+			t.Errorf("HSL(0, 1, 0.5) expected red, got %+v", red)
+		}
+	})
+
+	t.Run("LerpColor", func(t *testing.T) {
+		black := color.RGBA{R: 0, G: 0, B: 0, A: 255}
+		white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+
+		c0 := LerpColor(black, white, 0.0)
+		if c0 != black {
+			t.Errorf("LerpColor amt 0.0 expected black, got %+v", c0)
+		}
+
+		c1 := LerpColor(black, white, 1.0)
+		if c1 != white {
+			t.Errorf("LerpColor amt 1.0 expected white, got %+v", c1)
+		}
+
+		cMid := LerpColor(black, white, 0.5)
+		if cMid.R != 127 && cMid.R != 128 {
+			t.Errorf("LerpColor amt 0.5 expected ~128, got %+v", cMid)
+		}
+	})
+}
+
+func TestContext_ColorHelpers(t *testing.T) {
+	ctx := NewContext(10, 10)
+
+	ctx.BackgroundHSB(120, 1, 1)
+	pix := ctx.pix()
+	if pix[0] != 0 || pix[1] != 255 || pix[2] != 0 {
+		t.Errorf("BackgroundHSB expected green, got [%d %d %d]", pix[0], pix[1], pix[2])
+	}
+
+	ctx.FillHSB(0, 1, 1)
+	ctx.StrokeHSB(240, 1, 1)
+	ctx.FillHSBA(60, 1, 1, 0.8)
+	ctx.StrokeHSBA(180, 1, 1, 0.5)
+}

--- a/context.go
+++ b/context.go
@@ -100,6 +100,16 @@ func (ctx *Context) BackgroundHex(hex string) {
 	ctx.Pop()
 }
 
+// BackgroundHSB clears the canvas with an HSB color (h: 0-360, s: 0-1, b: 0-1).
+func (ctx *Context) BackgroundHSB(h, s, b float64) {
+	ctx.Background(HSB(h, s, b))
+}
+
+// BackgroundHSBA clears the canvas with an HSBA color (h: 0-360, s: 0-1, b: 0-1, a: 0-1).
+func (ctx *Context) BackgroundHSBA(h, s, b, a float64) {
+	ctx.Background(HSBA(h, s, b, a))
+}
+
 // FillColor sets the current drawing color.
 func (ctx *Context) FillColor(c color.Color) {
 	ctx.SetColor(c)
@@ -138,6 +148,26 @@ func (ctx *Context) FillHex(hex string) {
 // StrokeHex sets the drawing color with a hexadecimal string (e.g., "#ff0000").
 func (ctx *Context) StrokeHex(hex string) {
 	ctx.SetHexColor(hex)
+}
+
+// FillHSB sets the drawing color using Hue (0-360), Saturation (0-1), and Brightness (0-1).
+func (ctx *Context) FillHSB(h, s, b float64) {
+	ctx.SetColor(HSB(h, s, b))
+}
+
+// FillHSBA sets the drawing color using Hue (0-360), Saturation (0-1), Brightness (0-1), and Alpha (0-1).
+func (ctx *Context) FillHSBA(h, s, b, a float64) {
+	ctx.SetColor(HSBA(h, s, b, a))
+}
+
+// StrokeHSB sets the drawing color using Hue (0-360), Saturation (0-1), and Brightness (0-1).
+func (ctx *Context) StrokeHSB(h, s, b float64) {
+	ctx.SetColor(HSB(h, s, b))
+}
+
+// StrokeHSBA sets the drawing color using Hue (0-360), Saturation (0-1), Brightness (0-1), and Alpha (0-1).
+func (ctx *Context) StrokeHSBA(h, s, b, a float64) {
+	ctx.SetColor(HSBA(h, s, b, a))
 }
 
 // NoFill sets the fill color to transparent.


### PR DESCRIPTION
## Summary
Adds rich color and palette utilities frequently used in creative coding and generative art.

### Key Additions
1. **Color Model Conversions (`color.go`)**:
   - `canvas.HSB(h, s, b)` / `canvas.HSBA(h, s, b, a)`: Hue (0-360), Saturation (0-1), Brightness (0-1), Alpha (0-1).
   - `canvas.HSL(h, s, l)` / `canvas.HSLA(h, s, l, a)`.
   - `canvas.RGB(r, g, b)` / `canvas.RGBA(r, g, b, a)`: Convenient `color.RGBA` constructors.
   - `canvas.Hex("#hex")`: Hexadecimal parser supporting 3, 4, 6, and 8 hex digits.
2. **Color Interpolation (`color.go`)**:
   - `canvas.LerpColor(c1, c2, amt)`: Linear interpolation between two colors in RGBA space.
3. **Context Shortcuts (`context.go`)**:
   - `ctx.BackgroundHSB(...)`, `ctx.BackgroundHSBA(...)`
   - `ctx.FillHSB(...)`, `ctx.FillHSBA(...)`
   - `ctx.StrokeHSB(...)`, `ctx.StrokeHSBA(...)`
4. **Unit Tests**:
   - Comprehensive tests in `color_test.go`.