### PR TITLE
Add event callbacks (KeyPressed, MousePressed, MouseMoved)

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -20,15 +20,20 @@ type Canvas struct {
 	// FrameRate is the target frames per second.
 	FrameRate int
 
-	title      string
-	resizable  bool
-	fullscreen bool
-	looping    bool
-	redrawReq  bool
-	initFunc   func()
-	drawFunc   func()
-	context    *Context
-	mu         sync.Mutex
+	title             string
+	resizable         bool
+	fullscreen        bool
+	looping           bool
+	redrawReq         bool
+	initFunc          func()
+	drawFunc          func()
+	keyPressedFunc    func(*Context, Key)
+	keyReleasedFunc   func(*Context, Key)
+	mousePressedFunc  func(*Context, MouseButton)
+	mouseReleasedFunc func(*Context, MouseButton)
+	mouseMovedFunc    func(*Context, Vec)
+	context           *Context
+	mu                sync.Mutex
 }
 
 // CanvasConfig holds configuration parameters for creating a new Canvas.
@@ -114,6 +119,56 @@ func (c *Canvas) IsLooping() bool {
 	return c.looping
 }
 
+// KeyPressed registers a callback invoked when a keyboard key is pressed.
+func (c *Canvas) KeyPressed(fn func(*Context, Key)) {
+	c.keyPressedFunc = fn
+}
+
+// OnKeyPressed is an alias for KeyPressed.
+func (c *Canvas) OnKeyPressed(fn func(*Context, Key)) {
+	c.KeyPressed(fn)
+}
+
+// KeyReleased registers a callback invoked when a keyboard key is released.
+func (c *Canvas) KeyReleased(fn func(*Context, Key)) {
+	c.keyReleasedFunc = fn
+}
+
+// OnKeyReleased is an alias for KeyReleased.
+func (c *Canvas) OnKeyReleased(fn func(*Context, Key)) {
+	c.KeyReleased(fn)
+}
+
+// MousePressed registers a callback invoked when a mouse button is clicked.
+func (c *Canvas) MousePressed(fn func(*Context, MouseButton)) {
+	c.mousePressedFunc = fn
+}
+
+// OnMousePressed is an alias for MousePressed.
+func (c *Canvas) OnMousePressed(fn func(*Context, MouseButton)) {
+	c.MousePressed(fn)
+}
+
+// MouseReleased registers a callback invoked when a mouse button is released.
+func (c *Canvas) MouseReleased(fn func(*Context, MouseButton)) {
+	c.mouseReleasedFunc = fn
+}
+
+// OnMouseReleased is an alias for MouseReleased.
+func (c *Canvas) OnMouseReleased(fn func(*Context, MouseButton)) {
+	c.MouseReleased(fn)
+}
+
+// MouseMoved registers a callback invoked when the mouse cursor position changes.
+func (c *Canvas) MouseMoved(fn func(*Context, Vec)) {
+	c.mouseMovedFunc = fn
+}
+
+// OnMouseMoved is an alias for MouseMoved.
+func (c *Canvas) OnMouseMoved(fn func(*Context, Vec)) {
+	c.MouseMoved(fn)
+}
+
 // Setup registers an initialization function that runs once before the draw loop starts.
 func (c *Canvas) Setup(initializer func(*Context)) {
 	c.initFunc = func() {
@@ -173,6 +228,41 @@ func (c *Canvas) startLoop() {
 		c.context.IsMouseDragged = win.Pressed(pixel.MouseButtonLeft)
 		c.context.PMouse = c.context.Mouse
 		c.context.Mouse = toCanvasMousePos(win.MousePosition(), c.Height)
+
+		// Dispatch key events
+		if c.keyPressedFunc != nil {
+			for _, k := range allKeys {
+				if win.JustPressed(k) {
+					c.keyPressedFunc(c.context, k)
+				}
+			}
+		}
+		if c.keyReleasedFunc != nil {
+			for _, k := range allKeys {
+				if win.JustReleased(k) {
+					c.keyReleasedFunc(c.context, k)
+				}
+			}
+		}
+
+		// Dispatch mouse events
+		if c.mousePressedFunc != nil {
+			for _, btn := range allMouseButtons {
+				if win.JustPressed(btn) {
+					c.mousePressedFunc(c.context, btn)
+				}
+			}
+		}
+		if c.mouseReleasedFunc != nil {
+			for _, btn := range allMouseButtons {
+				if win.JustReleased(btn) {
+					c.mouseReleasedFunc(c.context, btn)
+				}
+			}
+		}
+		if c.mouseMovedFunc != nil && c.context.Mouse != c.context.PMouse {
+			c.mouseMovedFunc(c.context, c.context.Mouse)
+		}
 
 		c.mu.Lock()
 		shouldDraw := c.looping || c.redrawReq

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -345,6 +345,51 @@ func TestCanvas_NoLoop_FirstFrame(t *testing.T) {
 	}
 }
 
+func TestCanvas_EventCallbacks(t *testing.T) {
+	c := NewCanvas(nil)
+
+	keyPressedCount := 0
+	c.KeyPressed(func(ctx *Context, k Key) {
+		keyPressedCount++
+	})
+
+	mousePressedCount := 0
+	c.MousePressed(func(ctx *Context, btn MouseButton) {
+		mousePressedCount++
+	})
+
+	mouseMovedCount := 0
+	c.MouseMoved(func(ctx *Context, pos Vec) {
+		mouseMovedCount++
+	})
+
+	if c.keyPressedFunc == nil {
+		t.Error("expected keyPressedFunc to be set")
+	}
+	if c.mousePressedFunc == nil {
+		t.Error("expected mousePressedFunc to be set")
+	}
+	if c.mouseMovedFunc == nil {
+		t.Error("expected mouseMovedFunc to be set")
+	}
+
+	c.keyPressedFunc(c.context, KeySpace)
+	if keyPressedCount != 1 {
+		t.Errorf("expected keyPressedCount 1, got %d", keyPressedCount)
+	}
+
+	c.mousePressedFunc(c.context, MouseLeft)
+	if mousePressedCount != 1 {
+		t.Errorf("expected mousePressedCount 1, got %d", mousePressedCount)
+	}
+
+	c.mouseMovedFunc(c.context, V(100, 200))
+	if mouseMovedCount != 1 {
+		t.Errorf("expected mouseMovedCount 1, got %d", mouseMovedCount)
+	}
+}
+
+
 
 
 

--- a/input.go
+++ b/input.go
@@ -114,3 +114,22 @@ const (
 	KeyRightSuper   Key = pixel.KeyRightSuper
 	KeyMenu         Key = pixel.KeyMenu
 )
+
+var allKeys = []Key{
+	KeySpace, KeyApostrophe, KeyComma, KeyMinus, KeyPeriod, KeySlash,
+	Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7, Key8, Key9,
+	KeySemicolon, KeyEqual, KeyA, KeyB, KeyC, KeyD, KeyE, KeyF, KeyG,
+	KeyH, KeyI, KeyJ, KeyK, KeyL, KeyM, KeyN, KeyO, KeyP, KeyQ, KeyR,
+	KeyS, KeyT, KeyU, KeyV, KeyW, KeyX, KeyY, KeyZ, KeyLeftBracket,
+	KeyBackslash, KeyRightBracket, KeyGraveAccent, KeyEscape, KeyEnter,
+	KeyTab, KeyBackspace, KeyInsert, KeyDelete, KeyRight, KeyLeft,
+	KeyDown, KeyUp, KeyPageUp, KeyPageDown, KeyHome, KeyEnd, KeyCapsLock,
+	KeyScrollLock, KeyNumLock, KeyPrintScreen, KeyPause, KeyF1, KeyF2,
+	KeyF3, KeyF4, KeyF5, KeyF6, KeyF7, KeyF8, KeyF9, KeyF10, KeyF11,
+	KeyF12, KeyLeftShift, KeyLeftControl, KeyLeftAlt, KeyLeftSuper,
+	KeyRightShift, KeyRightControl, KeyRightAlt, KeyRightSuper, KeyMenu,
+}
+
+var allMouseButtons = []MouseButton{
+	MouseLeft, MouseRight, MouseMiddle,
+}


### PR DESCRIPTION
## Summary
Adds Processing-style event callback handlers to Canvas.

### Key Additions
1. **Event Callbacks (`canvas.go`)**:
   - `c.KeyPressed(func(ctx *canvas.Context, k Key))` / `c.OnKeyPressed(...)`
   - `c.KeyReleased(func(ctx *canvas.Context, k Key))` / `c.OnKeyReleased(...)`
   - `c.MousePressed(func(ctx *canvas.Context, btn MouseButton))` / `c.OnMousePressed(...)`
   - `c.MouseReleased(func(ctx *canvas.Context, btn MouseButton))` / `c.OnMouseReleased(...)`
   - `c.MouseMoved(func(ctx *canvas.Context, pos Vec))` / `c.OnMouseMoved(...)`
2. **Event Dispatching**:
   - Automated event scanning and dispatching inside `startLoop()`.