### PR TITLE
Add shape primitives (DrawSquare, DrawTriangle, DrawQuad) and custom shape path builders

### DIFF
--- a/context.go
+++ b/context.go
@@ -39,6 +39,7 @@ type Context struct {
 	pressed          func(Key) bool
 	justReleased     func(Key) bool
 	flippedPixBuffer []uint8
+	firstVertex      bool
 }
 
 // NewContext creates a new Context with the specified dimensions and sets the default basic font face.

--- a/shape.go
+++ b/shape.go
@@ -1,0 +1,46 @@
+package canvas
+
+// DrawSquare draws a square with top-left corner at (x, y) and side length s.
+func (ctx *Context) DrawSquare(x, y, s float64) {
+	ctx.DrawRectangle(x, y, s, s)
+}
+
+// DrawTriangle draws a triangle with vertices at (x1, y1), (x2, y2), and (x3, y3).
+func (ctx *Context) DrawTriangle(x1, y1, x2, y2, x3, y3 float64) {
+	ctx.MoveTo(x1, y1)
+	ctx.LineTo(x2, y2)
+	ctx.LineTo(x3, y3)
+	ctx.ClosePath()
+}
+
+// DrawQuad draws a quadrilateral with vertices at (x1, y1), (x2, y2), (x3, y3), and (x4, y4).
+func (ctx *Context) DrawQuad(x1, y1, x2, y2, x3, y3, x4, y4 float64) {
+	ctx.MoveTo(x1, y1)
+	ctx.LineTo(x2, y2)
+	ctx.LineTo(x3, y3)
+	ctx.LineTo(x4, y4)
+	ctx.ClosePath()
+}
+
+// BeginShape starts building a custom path using Vertex calls.
+func (ctx *Context) BeginShape() {
+	ctx.ClearPath()
+	ctx.firstVertex = true
+}
+
+// Vertex adds a coordinate point to the current custom shape path.
+func (ctx *Context) Vertex(x, y float64) {
+	if ctx.firstVertex {
+		ctx.MoveTo(x, y)
+		ctx.firstVertex = false
+	} else {
+		ctx.LineTo(x, y)
+	}
+}
+
+// EndShape completes the custom shape path. If close is true, the path is closed.
+func (ctx *Context) EndShape(close bool) {
+	if close {
+		ctx.ClosePath()
+	}
+}

--- a/shape_test.go
+++ b/shape_test.go
@@ -1,0 +1,71 @@
+package canvas
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestContext_ShapePrimitives(t *testing.T) {
+	ctx := NewContext(100, 100)
+
+	t.Run("DrawSquare", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 0, 0)
+		ctx.DrawSquare(10, 10, 20)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// (15, 15) should be red inside square
+		idx := (15*100 + 15) * 4
+		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 0 {
+			t.Errorf("DrawSquare: expected pixel inside square to be red, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+
+	t.Run("DrawTriangle", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(0, 1, 0)
+		ctx.DrawTriangle(0, 0, 40, 0, 20, 40)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// Centroid around (20, 15) should be green
+		idx := (15*100 + 20) * 4
+		if pix[idx] != 0 || pix[idx+1] != 255 || pix[idx+2] != 0 {
+			t.Errorf("DrawTriangle: expected centroid to be green, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+
+	t.Run("DrawQuad", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(0, 0, 1)
+		ctx.DrawQuad(10, 10, 50, 10, 40, 40, 0, 40)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// (25, 25) should be blue
+		idx := (25*100 + 25) * 4
+		if pix[idx] != 0 || pix[idx+1] != 0 || pix[idx+2] != 255 {
+			t.Errorf("DrawQuad: expected center to be blue, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+
+	t.Run("BeginShape and EndShape", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillColor(color.White)
+		ctx.BeginShape()
+		ctx.Vertex(20, 20)
+		ctx.Vertex(60, 20)
+		ctx.Vertex(60, 60)
+		ctx.Vertex(20, 60)
+		ctx.EndShape(true)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// (40, 40) should be white
+		idx := (40*100 + 40) * 4
+		if pix[idx] != 255 || pix[idx+1] != 255 || pix[idx+2] != 255 {
+			t.Errorf("BeginShape/EndShape: expected center to be white, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Adds Processing-style shape primitives and custom path recording to `Context`.

### Key Additions
1. **Shape Primitives (`shape.go`)**:
   - `ctx.DrawSquare(x, y, s)`
   - `ctx.DrawTriangle(x1, y1, x2, y2, x3, y3)`
   - `ctx.DrawQuad(x1, y1, x2, y2, x3, y3, x4, y4)`
2. **Custom Shape Builder (`shape.go`)**:
   - `ctx.BeginShape()`: Starts building a new custom path.
   - `ctx.Vertex(x, y)`: Adds vertices to the path.
   - `ctx.EndShape(close bool)`: Finalizes the custom shape.
3. **Unit Tests**:
   - Tests in `shape_test.go`.