### PR TITLE
Add SaveFrameSeq for sequential frame export

### DIFF
--- a/canvas_test.go
+++ b/canvas_test.go
@@ -2,6 +2,7 @@ package canvas
 
 import (
 	"image/color"
+	"os"
 	"testing"
 
 	"github.com/gopxl/pixel/v2"
@@ -302,6 +303,24 @@ func TestContext_SaveFrame(t *testing.T) {
 	err := ctx.SaveFrame(tmpFile)
 	if err != nil {
 		t.Fatalf("SaveFrame failed: %v", err)
+	}
+}
+
+func TestContext_SaveFrameSeq(t *testing.T) {
+	ctx := NewContext(10, 10)
+	ctx.BackgroundRGB(0, 1, 0)
+	ctx.FrameCount = 5
+
+	tmpDir := t.TempDir()
+	pattern := tmpDir + "/output_dir/frame_%04d.png"
+	err := ctx.SaveFrameSeq(pattern)
+	if err != nil {
+		t.Fatalf("SaveFrameSeq failed: %v", err)
+	}
+
+	expectedFile := tmpDir + "/output_dir/frame_0005.png"
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		t.Errorf("expected sequence file %s to exist", expectedFile)
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -2,8 +2,11 @@
 package canvas
 
 import (
+	"fmt"
 	"image"
 	"image/color"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/fogleman/gg"
@@ -184,6 +187,20 @@ func (ctx *Context) NoStroke() {
 // SaveFrame saves the current context buffer as a PNG image to the given path.
 func (ctx *Context) SaveFrame(path string) error {
 	return ctx.SavePNG(path)
+}
+
+// SaveFrameSeq saves the current context buffer as a formatted sequence frame.
+// pattern should contain a printf integer format verb (e.g. "frames/frame_%04d.png").
+// Parent directories are automatically created if they do not exist.
+func (ctx *Context) SaveFrameSeq(pattern string) error {
+	filePath := fmt.Sprintf(pattern, ctx.FrameCount)
+	dir := filepath.Dir(filePath)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	return ctx.SaveFrame(filePath)
 }
 
 // GetPixel returns the color of the pixel at (x, y) in canvas coordinates.


### PR DESCRIPTION
## Summary
Adds `ctx.SaveFrameSeq(pattern string)` to support automatic sequential frame exports for GIF/video generation.

### Key Additions
1. **`ctx.SaveFrameSeq(pattern string)` (`context.go`)**:
   - Formats `FrameCount` into file paths (e.g. `frames/frame_%04d.png`).
   - Automatically creates parent directories if needed.
2. **Unit Test**:
   - `TestContext_SaveFrameSeq` in `canvas_test.go`.