### PR TITLE
Feature: Animated GIF recording support (RecordGIF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It combines the power and simplicity of [`fogleman/gg`](https://github.com/fogle
 - **Simple & Intuitive**: Start animating with familiar `Setup` and `Draw` callbacks—no window or loop boilerplate.
 - **Rich 2D Vector Drawing**: Full 2D vector graphics (shapes, paths, text, images, colors, and transformations) powered by [`gg`](https://github.com/fogleman/gg).
 - **Interactive**: Built-in mouse and keyboard handling for interactive sketches, simulations, and creative coding.
+- **Easy Recording & Export**: Built-in automated animated GIF recording (`RecordGIF`) and sequential PNG frame capture (`SaveFrameSeq`).
 
 ## Installation
 
@@ -71,6 +72,7 @@ Check the [examples](examples) directory for complete programs:
 
 - [`drawline`](examples/drawline): Interactive mouse drawing and key interactions.
 - [`flow-field`](examples/flow-field): Organic flow field particles using HSB color and Perlin noise.
+- [`gif-export`](examples/gif-export): Automated animated GIF recording and exporting.
 - [`lifegame`](examples/lifegame): Conway's Game of Life simulation.
 - [`noise-landscape`](examples/noise-landscape): Organic wave animation with Perlin noise.
 - [`rotate-objects`](examples/rotate-objects): Coordinate system rotation and object transformations.

--- a/canvas.go
+++ b/canvas.go
@@ -33,6 +33,7 @@ type Canvas struct {
 	mouseReleasedFunc func(*Context, MouseButton)
 	mouseMovedFunc    func(*Context, Vec)
 	context           *Context
+	recorder          *gifRecorder
 	mu                sync.Mutex
 }
 
@@ -84,6 +85,7 @@ func NewCanvas(opts *CanvasConfig) *Canvas {
 		fullscreen: fullscreen,
 		looping:    true,
 		redrawReq:  true,
+		recorder:   newGIFRecorder(frameRate),
 	}
 	c.context = NewContext(width, height)
 	// set init drawer
@@ -117,6 +119,21 @@ func (c *Canvas) IsLooping() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.looping
+}
+
+// RecordGIF starts recording the specified number of rendered frames into an animated GIF file at path.
+// If opts is nil, default recording options are used.
+func (c *Canvas) RecordGIF(path string, frames int, opts ...*GIFOptions) {
+	var opt *GIFOptions
+	if len(opts) > 0 && opts[0] != nil {
+		opt = opts[0]
+	}
+	c.recorder.start(path, frames, opt)
+}
+
+// IsRecordingGIF returns true if a GIF recording is currently in progress.
+func (c *Canvas) IsRecordingGIF() bool {
+	return c.recorder.isRecording()
 }
 
 // KeyPressed registers a callback invoked when a keyboard key is pressed.
@@ -273,6 +290,7 @@ func (c *Canvas) startLoop() {
 			c.context.FrameCount++
 			c.drawFunc()
 			wincan.SetPixels(c.context.flippedPix())
+			c.recorder.capture(c.context)
 		}
 
 		win.Update()

--- a/context.go
+++ b/context.go
@@ -203,6 +203,15 @@ func (ctx *Context) SaveFrameSeq(pattern string) error {
 	return ctx.SaveFrame(filePath)
 }
 
+// CloneImage returns a deep copy of the current context RGBA image.
+func (ctx *Context) CloneImage() *image.RGBA {
+	src := ctx.Image().(*image.RGBA)
+	bounds := src.Bounds()
+	dst := image.NewRGBA(bounds)
+	copy(dst.Pix, src.Pix)
+	return dst
+}
+
 // GetPixel returns the color of the pixel at (x, y) in canvas coordinates.
 // If (x, y) is out of bounds, a transparent color is returned.
 func (ctx *Context) GetPixel(x, y int) color.RGBA {

--- a/examples/gif-export/main.go
+++ b/examples/gif-export/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/h8gi/canvas"
+)
+
+func main() {
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     400,
+		Height:    400,
+		FrameRate: 30,
+		Title:     "GIF Recording Example",
+	})
+
+	totalFrames := 60 // 2 seconds at 30 fps
+
+	c.Setup(func(ctx *canvas.Context) {
+		fmt.Printf("Recording %d frames to animation.gif...\n", totalFrames)
+
+		c.RecordGIF("animation.gif", totalFrames, &canvas.GIFOptions{
+			LoopCount: 0, // Infinite loop
+			OnComplete: func(path string, err error) {
+				if err != nil {
+					fmt.Printf("Failed to save GIF: %v\n", err)
+				} else {
+					fmt.Printf("Successfully recorded GIF to %s!\n", path)
+				}
+			},
+		})
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		ctx.BackgroundRGB(0.08, 0.08, 0.12)
+
+		t := float64(ctx.FrameCount) / float64(totalFrames) * math.Pi * 2
+		cx, cy := float64(ctx.Width())/2, float64(ctx.Height())/2
+		numPetals := 8
+
+		ctx.Push()
+		ctx.SetLineWidth(2.5)
+
+		for i := 0; i < numPetals; i++ {
+			angle := float64(i)*(2*math.Pi/float64(numPetals)) + t
+			dist := 70.0 + math.Sin(t+float64(i))*25.0
+			x := cx + math.Cos(angle)*dist
+			y := cy + math.Sin(angle)*dist
+
+			hue := math.Mod(float64(i)*(360.0/float64(numPetals))+float64(ctx.FrameCount)*4, 360)
+			ctx.StrokeHSBA(hue, 0.8, 0.95, 0.9)
+			ctx.FillHSBA(hue, 0.8, 0.95, 0.3)
+
+			ctx.DrawCircle(x, y, 24+math.Sin(t*2+float64(i))*8)
+			ctx.Fill()
+			ctx.Stroke()
+		}
+
+		ctx.Pop()
+
+		// Draw progress text
+		if ctx.FrameCount <= totalFrames {
+			ctx.FillRGB(0.8, 0.8, 0.8)
+			ctx.DrawString(fmt.Sprintf("Recording: %d / %d", ctx.FrameCount, totalFrames), 15, 30)
+		} else {
+			ctx.FillRGB(0.3, 0.9, 0.4)
+			ctx.DrawString("Recording complete!", 15, 30)
+		}
+	})
+}

--- a/gif.go
+++ b/gif.go
@@ -1,0 +1,204 @@
+package canvas
+
+import (
+	"fmt"
+	"image"
+	"image/color/palette"
+	"image/draw"
+	"image/gif"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// GIFOptions holds configuration options for recording and encoding animated GIFs.
+type GIFOptions struct {
+	// Delay is the frame delay in 100ths of a second (10ms units).
+	// If 0, delay is automatically calculated based on the canvas FrameRate (e.g. 60fps -> 2, 30fps -> 3).
+	Delay int
+	// LoopCount specifies the number of animation loops. 0 means infinite loop (default).
+	LoopCount int
+	// Dither enables Floyd-Steinberg dithering when converting RGBA frames to paletted images.
+	// Default is true.
+	Dither *bool
+	// OnComplete is an optional callback invoked when GIF encoding finishes.
+	OnComplete func(path string, err error)
+}
+
+type gifRecorder struct {
+	mu             sync.Mutex
+	active         bool
+	path           string
+	targetFrames   int
+	capturedFrames []*image.RGBA
+	opts           *GIFOptions
+	frameRate      int
+}
+
+func newGIFRecorder(frameRate int) *gifRecorder {
+	return &gifRecorder{
+		frameRate: frameRate,
+	}
+}
+
+func (r *gifRecorder) start(path string, frames int, opts *GIFOptions) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.path = path
+	r.targetFrames = frames
+	r.capturedFrames = make([]*image.RGBA, 0, frames)
+	r.opts = opts
+	r.active = true
+}
+
+func (r *gifRecorder) isRecording() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active
+}
+
+// capture copies the current context RGBA image and triggers encoding when targetFrames is reached.
+func (r *gifRecorder) capture(ctx *Context) {
+	r.mu.Lock()
+	if !r.active {
+		r.mu.Unlock()
+		return
+	}
+
+	src := ctx.Image().(*image.RGBA)
+	// Deep copy the pixel buffer
+	bounds := src.Bounds()
+	frameCopy := image.NewRGBA(bounds)
+	copy(frameCopy.Pix, src.Pix)
+	r.capturedFrames = append(r.capturedFrames, frameCopy)
+
+	if len(r.capturedFrames) >= r.targetFrames {
+		r.active = false
+		captured := r.capturedFrames
+		r.capturedFrames = nil
+		path := r.path
+		opts := r.opts
+		frameRate := r.frameRate
+		r.mu.Unlock()
+
+		go func() {
+			err := saveCapturedFramesAsGIF(path, captured, frameRate, opts)
+			if opts != nil && opts.OnComplete != nil {
+				opts.OnComplete(path, err)
+			}
+		}()
+		return
+	}
+	r.mu.Unlock()
+}
+
+func saveCapturedFramesAsGIF(path string, frames []*image.RGBA, frameRate int, opts *GIFOptions) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create GIF file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	images := make([]image.Image, len(frames))
+	for i, frame := range frames {
+		images[i] = frame
+	}
+
+	delay := 2
+	if frameRate > 0 {
+		delay = 100 / frameRate
+		if delay < 1 {
+			delay = 1
+		}
+	}
+	if opts != nil && opts.Delay > 0 {
+		delay = opts.Delay
+	}
+
+	return EncodeGIF(f, images, opts, delay)
+}
+
+// EncodeGIF encodes a slice of image.Image into an animated GIF written to w.
+func EncodeGIF(w io.Writer, images []image.Image, opts *GIFOptions, defaultDelay ...int) error {
+	if len(images) == 0 {
+		return fmt.Errorf("no frames provided for GIF encoding")
+	}
+
+	delayVal := 3
+	if len(defaultDelay) > 0 && defaultDelay[0] > 0 {
+		delayVal = defaultDelay[0]
+	}
+	if opts != nil && opts.Delay > 0 {
+		delayVal = opts.Delay
+	}
+
+	loopCount := 0
+	if opts != nil {
+		loopCount = opts.LoopCount
+	}
+
+	dither := true
+	if opts != nil && opts.Dither != nil {
+		dither = *opts.Dither
+	}
+
+	palettedFrames := make([]*image.Paletted, len(images))
+	delays := make([]int, len(images))
+
+	for i, img := range images {
+		palettedFrames[i] = ImageToPaletted(img, dither)
+		delays[i] = delayVal
+	}
+
+	anim := &gif.GIF{
+		Image:     palettedFrames,
+		Delay:     delays,
+		LoopCount: loopCount,
+	}
+
+	return gif.EncodeAll(w, anim)
+}
+
+// SaveGIF saves a sequence of images as an animated GIF file.
+func SaveGIF(path string, images []image.Image, opts *GIFOptions) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create GIF file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	return EncodeGIF(f, images, opts)
+}
+
+// ImageToPaletted converts an arbitrary image.Image to *image.Paletted using the standard Plan9 256-color palette.
+func ImageToPaletted(img image.Image, dither bool) *image.Paletted {
+	if paletted, ok := img.(*image.Paletted); ok {
+		return paletted
+	}
+
+	bounds := img.Bounds()
+	paletted := image.NewPaletted(bounds, palette.Plan9)
+
+	if dither {
+		draw.FloydSteinberg.Draw(paletted, bounds, img, bounds.Min)
+	} else {
+		draw.Src.Draw(paletted, bounds, img, bounds.Min)
+	}
+
+	return paletted
+}

--- a/gif_test.go
+++ b/gif_test.go
@@ -1,0 +1,221 @@
+package canvas
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/gif"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEncodeGIF(t *testing.T) {
+	// Create 3 simple dummy frames (10x10) with different colors
+	frames := make([]image.Image, 3)
+	colors := []color.RGBA{
+		{R: 255, G: 0, B: 0, A: 255},
+		{R: 0, G: 255, B: 0, A: 255},
+		{R: 0, G: 0, B: 255, A: 255},
+	}
+
+	for i := 0; i < 3; i++ {
+		img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+		for y := 0; y < 10; y++ {
+			for x := 0; x < 10; x++ {
+				img.Set(x, y, colors[i])
+			}
+		}
+		frames[i] = img
+	}
+
+	t.Run("default options", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := EncodeGIF(&buf, frames, nil)
+		if err != nil {
+			t.Fatalf("EncodeGIF failed: %v", err)
+		}
+
+		decoded, err := gif.DecodeAll(&buf)
+		if err != nil {
+			t.Fatalf("failed to decode generated GIF: %v", err)
+		}
+
+		if len(decoded.Image) != 3 {
+			t.Errorf("expected 3 frames, got %d", len(decoded.Image))
+		}
+		if decoded.LoopCount != 0 {
+			t.Errorf("expected LoopCount 0, got %d", decoded.LoopCount)
+		}
+	})
+
+	t.Run("custom options with delay and loop count", func(t *testing.T) {
+		var buf bytes.Buffer
+		dither := false
+		opts := &GIFOptions{
+			Delay:     10,
+			LoopCount: 5,
+			Dither:    &dither,
+		}
+		err := EncodeGIF(&buf, frames, opts)
+		if err != nil {
+			t.Fatalf("EncodeGIF failed: %v", err)
+		}
+
+		decoded, err := gif.DecodeAll(&buf)
+		if err != nil {
+			t.Fatalf("failed to decode generated GIF: %v", err)
+		}
+
+		if len(decoded.Image) != 3 {
+			t.Errorf("expected 3 frames, got %d", len(decoded.Image))
+		}
+		if decoded.LoopCount != 5 {
+			t.Errorf("expected LoopCount 5, got %d", decoded.LoopCount)
+		}
+		for i, d := range decoded.Delay {
+			if d != 10 {
+				t.Errorf("expected frame %d delay to be 10, got %d", i, d)
+			}
+		}
+	})
+
+	t.Run("empty frames error", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := EncodeGIF(&buf, nil, nil)
+		if err == nil {
+			t.Error("expected error for empty frames, got nil")
+		}
+	})
+}
+
+func TestSaveGIF(t *testing.T) {
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "sub", "test.gif")
+
+	img1 := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	img2 := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	frames := []image.Image{img1, img2}
+
+	err := SaveGIF(outPath, frames, nil)
+	if err != nil {
+		t.Fatalf("SaveGIF failed: %v", err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("GIF file was not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Errorf("GIF file is empty")
+	}
+}
+
+func TestGIFRecorder(t *testing.T) {
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "record.gif")
+
+	rec := newGIFRecorder(60)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var callbackPath string
+	var callbackErr error
+
+	opts := &GIFOptions{
+		OnComplete: func(path string, err error) {
+			callbackPath = path
+			callbackErr = err
+			wg.Done()
+		},
+	}
+
+	rec.start(outPath, 3, opts)
+	if !rec.isRecording() {
+		t.Error("expected recorder to be active")
+	}
+
+	ctx := NewContext(10, 10)
+
+	// Capture frame 1
+	ctx.BackgroundRGB(1, 0, 0)
+	rec.capture(ctx)
+	if !rec.isRecording() {
+		t.Error("expected recorder to still be active after frame 1")
+	}
+
+	// Capture frame 2
+	ctx.BackgroundRGB(0, 1, 0)
+	rec.capture(ctx)
+	if !rec.isRecording() {
+		t.Error("expected recorder to still be active after frame 2")
+	}
+
+	// Capture frame 3 (triggers complete)
+	ctx.BackgroundRGB(0, 0, 1)
+	rec.capture(ctx)
+	if rec.isRecording() {
+		t.Error("expected recorder to become inactive after reaching target frames")
+	}
+
+	// Wait for async encoding
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if callbackErr != nil {
+			t.Fatalf("recording complete callback returned error: %v", callbackErr)
+		}
+		if callbackPath != outPath {
+			t.Errorf("expected callback path %s, got %s", outPath, callbackPath)
+		}
+		// Verify file exists
+		if _, err := os.Stat(outPath); os.IsNotExist(err) {
+			t.Errorf("expected recorded GIF file to exist: %s", outPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GIF recording completion")
+	}
+}
+
+func TestCanvas_RecordGIF_Integration(t *testing.T) {
+	c := NewCanvas(nil)
+	if c.IsRecordingGIF() {
+		t.Error("expected IsRecordingGIF to be false initially")
+	}
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "canvas_record.gif")
+
+	c.RecordGIF(outPath, 10)
+	if !c.IsRecordingGIF() {
+		t.Error("expected IsRecordingGIF to be true after RecordGIF call")
+	}
+}
+
+func TestContext_CloneImage(t *testing.T) {
+	ctx := NewContext(10, 10)
+	ctx.BackgroundRGB(1, 0, 0)
+
+	cloned := ctx.CloneImage()
+	if cloned == nil {
+		t.Fatal("expected cloned image to not be nil")
+	}
+
+	// Verify cloned pixels match
+	if cloned.Pix[0] != 255 || cloned.Pix[1] != 0 || cloned.Pix[2] != 0 {
+		t.Errorf("cloned image pixel mismatch")
+	}
+
+	// Modify original context, cloned should remain unchanged
+	ctx.BackgroundRGB(0, 0, 1)
+	if cloned.Pix[0] != 255 || cloned.Pix[2] != 0 {
+		t.Errorf("cloned image was mutated when context changed")
+	}
+}


### PR DESCRIPTION
Closes #24

### Summary of Changes
- Added `RecordGIF` and `IsRecordingGIF` methods to `Canvas` for automated animated GIF capturing.
- Implemented GIF encoding pipeline in `gif.go` using standard library `image/gif` with configurable delay, loop count, and Floyd-Steinberg dithering.
- Added `CloneImage()` helper to `Context` for deep-copying frame buffers.
- Added unit tests in `gif_test.go` covering GIF encoding, file export, and recorder callbacks.
- Added `examples/gif-export` demonstrating animated GIF recording with completion callback.
- Updated `README.md` features and examples list.