### PR TITLE
Feature: Shape primitives expansion (Polygon, Star, Arc, Sector, RectMode)

### DIFF
--- a/context.go
+++ b/context.go
@@ -43,6 +43,8 @@ type Context struct {
 	justReleased     func(Key) bool
 	flippedPixBuffer []uint8
 	firstVertex      bool
+	rectMode         RectMode
+	ellipseMode      EllipseMode
 }
 
 // NewContext creates a new Context with the specified dimensions and sets the default basic font face.

--- a/shape.go
+++ b/shape.go
@@ -1,8 +1,79 @@
 package canvas
 
+import "math"
+
+// RectMode represents how rectangle coordinates are interpreted.
+type RectMode int
+
+const (
+	// RectModeCorner interprets (x, y) as the top-left corner (default).
+	RectModeCorner RectMode = iota
+	// RectModeCenter interprets (x, y) as the center point.
+	RectModeCenter
+	// RectModeRadius interprets (x, y) as the center point, and (w, h) as half-width and half-height.
+	RectModeRadius
+)
+
+// EllipseMode represents how ellipse / circle coordinates are interpreted.
+type EllipseMode int
+
+const (
+	// EllipseModeCenter interprets (x, y) as the center point (default).
+	EllipseModeCenter EllipseMode = iota
+	// EllipseModeCorner interprets (x, y) as the top-left corner of the bounding box.
+	EllipseModeCorner
+	// EllipseModeRadius interprets (x, y) as the center point, and (w, h) as horizontal and vertical radii.
+	EllipseModeRadius
+)
+
+// SetRectMode sets the current rectangle drawing mode (RectModeCorner, RectModeCenter, or RectModeRadius).
+func (ctx *Context) SetRectMode(mode RectMode) {
+	ctx.rectMode = mode
+}
+
+// SetEllipseMode sets the current ellipse drawing mode (EllipseModeCenter, EllipseModeCorner, or EllipseModeRadius).
+func (ctx *Context) SetEllipseMode(mode EllipseMode) {
+	ctx.ellipseMode = mode
+}
+
 // DrawSquare draws a square with top-left corner at (x, y) and side length s.
 func (ctx *Context) DrawSquare(x, y, s float64) {
 	ctx.DrawRectangle(x, y, s, s)
+}
+
+// DrawCenteredRectangle draws a rectangle centered at (x, y) with width w and height h.
+func (ctx *Context) DrawCenteredRectangle(x, y, w, h float64) {
+	ctx.DrawRectangle(x-w/2.0, y-h/2.0, w, h)
+}
+
+// DrawCenteredSquare draws a square centered at (x, y) with side length s.
+func (ctx *Context) DrawCenteredSquare(x, y, s float64) {
+	ctx.DrawRectangle(x-s/2.0, y-s/2.0, s, s)
+}
+
+// DrawRect draws a rectangle using the current RectMode.
+func (ctx *Context) DrawRect(x, y, w, h float64) {
+	switch ctx.rectMode {
+	case RectModeCenter:
+		ctx.DrawRectangle(x-w/2.0, y-h/2.0, w, h)
+	case RectModeRadius:
+		ctx.DrawRectangle(x-w, y-h, w*2.0, h*2.0)
+	default: // RectModeCorner
+		ctx.DrawRectangle(x, y, w, h)
+	}
+}
+
+// DrawEllipseMode draws an ellipse using the current EllipseMode.
+// In default EllipseModeCenter, (w, h) are the full width and height (diameters).
+func (ctx *Context) DrawEllipseMode(x, y, w, h float64) {
+	switch ctx.ellipseMode {
+	case EllipseModeCorner:
+		ctx.DrawEllipse(x+w/2.0, y+h/2.0, w/2.0, h/2.0)
+	case EllipseModeRadius:
+		ctx.DrawEllipse(x, y, w, h)
+	default: // EllipseModeCenter
+		ctx.DrawEllipse(x, y, w/2.0, h/2.0)
+	}
 }
 
 // DrawTriangle draws a triangle with vertices at (x1, y1), (x2, y2), and (x3, y3).
@@ -19,6 +90,65 @@ func (ctx *Context) DrawQuad(x1, y1, x2, y2, x3, y3, x4, y4 float64) {
 	ctx.LineTo(x2, y2)
 	ctx.LineTo(x3, y3)
 	ctx.LineTo(x4, y4)
+	ctx.ClosePath()
+}
+
+// DrawPolygon draws a regular polygon centered at (x, y) with the specified outer radius and number of sides.
+func (ctx *Context) DrawPolygon(x, y, radius float64, sides int) {
+	if sides < 3 || radius <= 0 {
+		return
+	}
+
+	angleStep := (math.Pi * 2.0) / float64(sides)
+	startAngle := -math.Pi / 2.0 // Top vertex first
+
+	for i := 0; i < sides; i++ {
+		angle := startAngle + float64(i)*angleStep
+		px := x + radius*math.Cos(angle)
+		py := y + radius*math.Sin(angle)
+		if i == 0 {
+			ctx.MoveTo(px, py)
+		} else {
+			ctx.LineTo(px, py)
+		}
+	}
+	ctx.ClosePath()
+}
+
+// DrawStar draws an n-pointed star centered at (x, y) with outer radius radius1 and inner radius radius2.
+func (ctx *Context) DrawStar(x, y, radius1, radius2 float64, points int) {
+	if points < 2 || radius1 <= 0 || radius2 <= 0 {
+		return
+	}
+
+	totalVertices := points * 2
+	angleStep := math.Pi / float64(points)
+	startAngle := -math.Pi / 2.0 // Top vertex first
+
+	for i := 0; i < totalVertices; i++ {
+		r := radius1
+		if i%2 != 0 {
+			r = radius2
+		}
+		angle := startAngle + float64(i)*angleStep
+		px := x + r*math.Cos(angle)
+		py := y + r*math.Sin(angle)
+		if i == 0 {
+			ctx.MoveTo(px, py)
+		} else {
+			ctx.LineTo(px, py)
+		}
+	}
+	ctx.ClosePath()
+}
+
+// DrawSector draws a pie/wedge sector centered at (x, y) with radius r between startAngle and endAngle (in radians).
+func (ctx *Context) DrawSector(x, y, r, startAngle, endAngle float64) {
+	if r <= 0 {
+		return
+	}
+	ctx.MoveTo(x, y)
+	ctx.DrawEllipticalArc(x, y, r, r, startAngle, endAngle)
 	ctx.ClosePath()
 }
 

--- a/shape_test.go
+++ b/shape_test.go
@@ -2,6 +2,7 @@ package canvas
 
 import (
 	"image/color"
+	"math"
 	"testing"
 )
 
@@ -20,6 +21,90 @@ func TestContext_ShapePrimitives(t *testing.T) {
 		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 0 {
 			t.Errorf("DrawSquare: expected pixel inside square to be red, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
 		}
+	})
+
+	t.Run("DrawCenteredRectangle and DrawCenteredSquare", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 1, 0)
+		ctx.DrawCenteredRectangle(50, 50, 20, 30)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// (50, 50) should be yellow
+		idx := (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 255 || pix[idx+2] != 0 {
+			t.Errorf("DrawCenteredRectangle: expected center to be yellow, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(0, 1, 1)
+		ctx.DrawCenteredSquare(50, 50, 20)
+		ctx.Fill()
+
+		pix = ctx.pix()
+		// (50, 50) should be cyan
+		idx = (50*100 + 50) * 4
+		if pix[idx] != 0 || pix[idx+1] != 255 || pix[idx+2] != 255 {
+			t.Errorf("DrawCenteredSquare: expected center to be cyan, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+
+	t.Run("RectMode", func(t *testing.T) {
+		// Test RectModeCenter
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 0, 0)
+		ctx.SetRectMode(RectModeCenter)
+		ctx.DrawRect(50, 50, 20, 20)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		idx := (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 0 {
+			t.Errorf("RectModeCenter: expected center to be red, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		// Test RectModeRadius
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(0, 1, 0)
+		ctx.SetRectMode(RectModeRadius)
+		ctx.DrawRect(50, 50, 10, 10)
+		ctx.Fill()
+
+		pix = ctx.pix()
+		idx = (50*100 + 50) * 4
+		if pix[idx] != 0 || pix[idx+1] != 255 || pix[idx+2] != 0 {
+			t.Errorf("RectModeRadius: expected center to be green, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		// Reset to default RectModeCorner
+		ctx.SetRectMode(RectModeCorner)
+	})
+
+	t.Run("EllipseMode", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 0, 1)
+		ctx.SetEllipseMode(EllipseModeCenter)
+		ctx.DrawEllipseMode(50, 50, 20, 20)
+		ctx.Fill()
+
+		pix := ctx.pix()
+		idx := (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 255 {
+			t.Errorf("EllipseModeCenter: expected center to be magenta, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.SetEllipseMode(EllipseModeCorner)
+		ctx.DrawEllipseMode(40, 40, 20, 20)
+		ctx.Fill()
+
+		pix = ctx.pix()
+		idx = (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 255 {
+			t.Errorf("EllipseModeCorner: expected center (50,50) to be magenta, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		ctx.SetEllipseMode(EllipseModeCenter)
 	})
 
 	t.Run("DrawTriangle", func(t *testing.T) {
@@ -47,6 +132,52 @@ func TestContext_ShapePrimitives(t *testing.T) {
 		idx := (25*100 + 25) * 4
 		if pix[idx] != 0 || pix[idx+1] != 0 || pix[idx+2] != 255 {
 			t.Errorf("DrawQuad: expected center to be blue, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+	})
+
+	t.Run("DrawPolygon", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 0, 0)
+		ctx.DrawPolygon(50, 50, 20, 6) // Hexagon
+		ctx.Fill()
+
+		pix := ctx.pix()
+		idx := (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 0 || pix[idx+2] != 0 {
+			t.Errorf("DrawPolygon: expected center to be red, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		// Invalid sides (< 3) should safely no-op
+		ctx.DrawPolygon(50, 50, 20, 2)
+	})
+
+	t.Run("DrawStar", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(1, 1, 0)
+		ctx.DrawStar(50, 50, 30, 15, 5) // 5-pointed star
+		ctx.Fill()
+
+		pix := ctx.pix()
+		idx := (50*100 + 50) * 4
+		if pix[idx] != 255 || pix[idx+1] != 255 || pix[idx+2] != 0 {
+			t.Errorf("DrawStar: expected center to be yellow, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
+		}
+
+		// Invalid points (< 2) should safely no-op
+		ctx.DrawStar(50, 50, 30, 15, 1)
+	})
+
+	t.Run("DrawSector", func(t *testing.T) {
+		ctx.BackgroundRGB(0, 0, 0)
+		ctx.FillRGB(0, 0, 1)
+		ctx.DrawSector(50, 50, 25, 0, math.Pi) // Half circle
+		ctx.Fill()
+
+		pix := ctx.pix()
+		// (50, 60) in lower half should be blue
+		idx := (60*100 + 50) * 4
+		if pix[idx] != 0 || pix[idx+1] != 0 || pix[idx+2] != 255 {
+			t.Errorf("DrawSector: expected interior of sector to be blue, got [%d %d %d]", pix[idx], pix[idx+1], pix[idx+2])
 		}
 	})
 


### PR DESCRIPTION
Closes #25

### Summary of Changes
- Added `DrawPolygon(x, y, radius, sides)` for regular polygons (pentagon, hexagon, etc.).
- Added `DrawStar(x, y, radius1, radius2, points)` for n-pointed star shapes.
- Added `DrawSector(x, y, radius, startAngle, endAngle)` for pie/wedge shapes.
- Added `DrawCenteredRectangle` and `DrawCenteredSquare` for center-based positioning.
- Added `RectMode` and `EllipseMode` support (`SetRectMode`, `SetEllipseMode`, `DrawRect`, `DrawEllipseMode`).
- Added comprehensive unit tests in `shape_test.go`.