### PR TITLE
Feature: 2D vector arithmetic and manipulation helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,13 @@ flycheck_*.el
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Generated media / recordings (except assets/)
+*.png
+*.gif
+!assets/*.png
+!assets/*.gif
+
 # Dependency directories (remove the comment below to include it)
 vendor/
-
 
 README.html

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,103 @@
+package canvas
+
+import "math"
+
+// VecAdd adds two vectors v1 and v2 and returns the result.
+func VecAdd(v1, v2 Vec) Vec {
+	return V(v1.X+v2.X, v1.Y+v2.Y)
+}
+
+// VecSub subtracts vector v2 from v1 and returns the result.
+func VecSub(v1, v2 Vec) Vec {
+	return V(v1.X-v2.X, v1.Y-v2.Y)
+}
+
+// VecMult multiplies a vector by a scalar and returns the result.
+func VecMult(v Vec, scalar float64) Vec {
+	return V(v.X*scalar, v.Y*scalar)
+}
+
+// VecDiv divides a vector by a scalar and returns the result.
+// If scalar is 0, it returns the original vector unchanged.
+func VecDiv(v Vec, scalar float64) Vec {
+	if scalar == 0 {
+		return v
+	}
+	return V(v.X/scalar, v.Y/scalar)
+}
+
+// VecMag calculates the magnitude (length) of the vector.
+func VecMag(v Vec) float64 {
+	return math.Hypot(v.X, v.Y)
+}
+
+// VecMagSq calculates the squared magnitude of the vector.
+func VecMagSq(v Vec) float64 {
+	return v.X*v.X + v.Y*v.Y
+}
+
+// VecNormalize returns a unit vector pointing in the same direction as v.
+// If v is a zero vector, it returns V(0, 0).
+func VecNormalize(v Vec) Vec {
+	m := VecMag(v)
+	if m == 0 {
+		return V(0, 0)
+	}
+	return V(v.X/m, v.Y/m)
+}
+
+// VecSetMag returns a new vector with the same direction as v and the specified magnitude.
+func VecSetMag(v Vec, length float64) Vec {
+	return VecMult(VecNormalize(v), length)
+}
+
+// VecLimit constrains the magnitude of the vector to the given max value.
+func VecLimit(v Vec, max float64) Vec {
+	magSq := VecMagSq(v)
+	if magSq > max*max {
+		return VecMult(VecNormalize(v), max)
+	}
+	return v
+}
+
+// VecDist calculates the Euclidean distance between two vectors.
+func VecDist(v1, v2 Vec) float64 {
+	return Dist(v1.X, v1.Y, v2.X, v2.Y)
+}
+
+// VecDot calculates the dot product of two vectors.
+func VecDot(v1, v2 Vec) float64 {
+	return v1.X*v2.X + v1.Y*v2.Y
+}
+
+// VecCross calculates the 2D cross product (determinant) of two vectors.
+func VecCross(v1, v2 Vec) float64 {
+	return v1.X*v2.Y - v1.Y*v2.X
+}
+
+// VecRotate rotates a 2D vector by an angle in radians.
+func VecRotate(v Vec, rad float64) Vec {
+	cos := math.Cos(rad)
+	sin := math.Sin(rad)
+	return V(v.X*cos-v.Y*sin, v.X*sin+v.Y*cos)
+}
+
+// VecAngleBetween calculates the angle (in radians) between two vectors.
+func VecAngleBetween(v1, v2 Vec) float64 {
+	m1 := VecMag(v1)
+	m2 := VecMag(v2)
+	if m1 == 0 || m2 == 0 {
+		return 0
+	}
+	dot := VecDot(v1, v2) / (m1 * m2)
+	dot = Constrain(dot, -1.0, 1.0)
+	return math.Acos(dot)
+}
+
+// VecLerp linear-interpolates between two vectors at increment amt (0.0 to 1.0).
+func VecLerp(v1, v2 Vec, amt float64) Vec {
+	return V(
+		Lerp(v1.X, v2.X, amt),
+		Lerp(v1.Y, v2.Y, amt),
+	)
+}

--- a/vector_test.go
+++ b/vector_test.go
@@ -1,0 +1,132 @@
+package canvas
+
+import (
+	"math"
+	"testing"
+)
+
+func TestVectorOperations(t *testing.T) {
+	t.Run("VecAdd and VecSub", func(t *testing.T) {
+		v1 := V(3, 4)
+		v2 := V(1, 2)
+
+		add := VecAdd(v1, v2)
+		if add.X != 4 || add.Y != 6 {
+			t.Errorf("VecAdd expected (4,6), got (%v,%v)", add.X, add.Y)
+		}
+
+		sub := VecSub(v1, v2)
+		if sub.X != 2 || sub.Y != 2 {
+			t.Errorf("VecSub expected (2,2), got (%v,%v)", sub.X, sub.Y)
+		}
+	})
+
+	t.Run("VecMult and VecDiv", func(t *testing.T) {
+		v := V(2, 3)
+
+		mult := VecMult(v, 2.5)
+		if mult.X != 5 || mult.Y != 7.5 {
+			t.Errorf("VecMult expected (5, 7.5), got (%v,%v)", mult.X, mult.Y)
+		}
+
+		div := VecDiv(v, 2)
+		if div.X != 1 || div.Y != 1.5 {
+			t.Errorf("VecDiv expected (1, 1.5), got (%v,%v)", div.X, div.Y)
+		}
+
+		// Division by 0 returns unmodified
+		divZero := VecDiv(v, 0)
+		if divZero != v {
+			t.Errorf("VecDiv by 0 expected original vector, got (%v,%v)", divZero.X, divZero.Y)
+		}
+	})
+
+	t.Run("VecMag and VecMagSq", func(t *testing.T) {
+		v := V(3, 4)
+		if VecMag(v) != 5.0 {
+			t.Errorf("VecMag expected 5.0, got %v", VecMag(v))
+		}
+		if VecMagSq(v) != 25.0 {
+			t.Errorf("VecMagSq expected 25.0, got %v", VecMagSq(v))
+		}
+	})
+
+	t.Run("VecNormalize and VecSetMag", func(t *testing.T) {
+		v := V(0, 10)
+		norm := VecNormalize(v)
+		if norm.X != 0 || norm.Y != 1.0 {
+			t.Errorf("VecNormalize expected (0,1), got (%v,%v)", norm.X, norm.Y)
+		}
+
+		zeroNorm := VecNormalize(V(0, 0))
+		if zeroNorm.X != 0 || zeroNorm.Y != 0 {
+			t.Errorf("VecNormalize of (0,0) expected (0,0), got (%v,%v)", zeroNorm.X, zeroNorm.Y)
+		}
+
+		setMag := VecSetMag(V(3, 4), 10.0)
+		if math.Abs(VecMag(setMag)-10.0) > 1e-6 {
+			t.Errorf("VecSetMag expected magnitude 10.0, got %v", VecMag(setMag))
+		}
+		if math.Abs(setMag.X-6.0) > 1e-6 || math.Abs(setMag.Y-8.0) > 1e-6 {
+			t.Errorf("VecSetMag expected (6,8), got (%v,%v)", setMag.X, setMag.Y)
+		}
+	})
+
+	t.Run("VecLimit", func(t *testing.T) {
+		v := V(30, 40) // mag = 50
+		limited := VecLimit(v, 10)
+		if math.Abs(VecMag(limited)-10.0) > 1e-6 {
+			t.Errorf("VecLimit expected magnitude 10.0, got %v", VecMag(limited))
+		}
+
+		// Within limit should not change
+		unlimited := VecLimit(V(3, 4), 10)
+		if unlimited.X != 3 || unlimited.Y != 4 {
+			t.Errorf("VecLimit within limit changed vector: (%v,%v)", unlimited.X, unlimited.Y)
+		}
+	})
+
+	t.Run("VecDist, VecDot, and VecCross", func(t *testing.T) {
+		v1 := V(0, 0)
+		v2 := V(3, 4)
+		if VecDist(v1, v2) != 5.0 {
+			t.Errorf("VecDist expected 5.0, got %v", VecDist(v1, v2))
+		}
+
+		// Dot product of orthogonal vectors is 0
+		if VecDot(V(1, 0), V(0, 1)) != 0 {
+			t.Errorf("VecDot expected 0, got %v", VecDot(V(1, 0), V(0, 1)))
+		}
+		// Dot product of parallel vectors
+		if VecDot(V(2, 3), V(4, 5)) != 23 {
+			t.Errorf("VecDot expected 23, got %v", VecDot(V(2, 3), V(4, 5)))
+		}
+
+		// Cross product: (1, 0) x (0, 1) = 1
+		if VecCross(V(1, 0), V(0, 1)) != 1 {
+			t.Errorf("VecCross expected 1, got %v", VecCross(V(1, 0), V(0, 1)))
+		}
+	})
+
+	t.Run("VecRotate and VecAngleBetween", func(t *testing.T) {
+		v := V(1, 0)
+		rotated := VecRotate(v, math.Pi/2)
+		if math.Abs(rotated.X) > 1e-6 || math.Abs(rotated.Y-1.0) > 1e-6 {
+			t.Errorf("VecRotate by 90 deg expected (0,1), got (%v,%v)", rotated.X, rotated.Y)
+		}
+
+		angle := VecAngleBetween(V(1, 0), V(0, 1))
+		if math.Abs(angle-math.Pi/2) > 1e-6 {
+			t.Errorf("VecAngleBetween expected pi/2, got %v", angle)
+		}
+	})
+
+	t.Run("VecLerp", func(t *testing.T) {
+		v1 := V(0, 10)
+		v2 := V(10, 20)
+		lerped := VecLerp(v1, v2, 0.5)
+		if lerped.X != 5 || lerped.Y != 15 {
+			t.Errorf("VecLerp at 0.5 expected (5,15), got (%v,%v)", lerped.X, lerped.Y)
+		}
+	})
+}


### PR DESCRIPTION
Closes #26

### Summary of Changes
- Added 2D vector operations in `vector.go`:
  - Arithmetic: `VecAdd`, `VecSub`, `VecMult`, `VecDiv`
  - Length & Normalization: `VecMag`, `VecMagSq`, `VecNormalize`, `VecSetMag`, `VecLimit`
  - Geometry: `VecDist`, `VecDot`, `VecCross`, `VecRotate`, `VecAngleBetween`, `VecLerp`
- Added comprehensive unit tests in `vector_test.go`.
- Updated `.gitignore` to ignore local generated output files.