### PR TITLE
Feature: Advanced noise & easing functions (FBM noise & animation easings)

### DIFF
--- a/easing.go
+++ b/easing.go
@@ -1,0 +1,223 @@
+package canvas
+
+import "math"
+
+// EaseLinear performs linear interpolation (constant speed).
+func EaseLinear(t float64) float64 {
+	return t
+}
+
+// EaseInSine accelerates using a sine curve.
+func EaseInSine(t float64) float64 {
+	return 1.0 - math.Cos((t*math.Pi)/2.0)
+}
+
+// EaseOutSine decelerates using a sine curve.
+func EaseOutSine(t float64) float64 {
+	return math.Sin((t * math.Pi) / 2.0)
+}
+
+// EaseInOutSine accelerates then decelerates using a sine curve.
+func EaseInOutSine(t float64) float64 {
+	return -(math.Cos(math.Pi*t) - 1.0) / 2.0
+}
+
+// EaseInQuad accelerates using a quadratic curve (t^2).
+func EaseInQuad(t float64) float64 {
+	return t * t
+}
+
+// EaseOutQuad decelerates using a quadratic curve.
+func EaseOutQuad(t float64) float64 {
+	return 1.0 - (1.0-t)*(1.0-t)
+}
+
+// EaseInOutQuad accelerates then decelerates using a quadratic curve.
+func EaseInOutQuad(t float64) float64 {
+	if t < 0.5 {
+		return 2.0 * t * t
+	}
+	return 1.0 - math.Pow(-2.0*t+2.0, 2.0)/2.0
+}
+
+// EaseInCubic accelerates using a cubic curve (t^3).
+func EaseInCubic(t float64) float64 {
+	return t * t * t
+}
+
+// EaseOutCubic decelerates using a cubic curve.
+func EaseOutCubic(t float64) float64 {
+	return 1.0 - math.Pow(1.0-t, 3.0)
+}
+
+// EaseInOutCubic accelerates then decelerates using a cubic curve.
+func EaseInOutCubic(t float64) float64 {
+	if t < 0.5 {
+		return 4.0 * t * t * t
+	}
+	return 1.0 - math.Pow(-2.0*t+2.0, 3.0)/2.0
+}
+
+// EaseInQuart accelerates using a quartic curve (t^4).
+func EaseInQuart(t float64) float64 {
+	return t * t * t * t
+}
+
+// EaseOutQuart decelerates using a quartic curve.
+func EaseOutQuart(t float64) float64 {
+	return 1.0 - math.Pow(1.0-t, 4.0)
+}
+
+// EaseInOutQuart accelerates then decelerates using a quartic curve.
+func EaseInOutQuart(t float64) float64 {
+	if t < 0.5 {
+		return 8.0 * t * t * t * t
+	}
+	return 1.0 - math.Pow(-2.0*t+2.0, 4.0)/2.0
+}
+
+// EaseInExpo accelerates exponentially.
+func EaseInExpo(t float64) float64 {
+	if t == 0 {
+		return 0
+	}
+	return math.Pow(2.0, 10.0*t-10.0)
+}
+
+// EaseOutExpo decelerates exponentially.
+func EaseOutExpo(t float64) float64 {
+	if t >= 1.0 {
+		return 1.0
+	}
+	return 1.0 - math.Pow(2.0, -10.0*t)
+}
+
+// EaseInOutExpo accelerates then decelerates exponentially.
+func EaseInOutExpo(t float64) float64 {
+	if t <= 0 {
+		return 0
+	}
+	if t >= 1.0 {
+		return 1.0
+	}
+	if t < 0.5 {
+		return math.Pow(2.0, 20.0*t-10.0) / 2.0
+	}
+	return (2.0 - math.Pow(2.0, -20.0*t+10.0)) / 2.0
+}
+
+// EaseInCirc accelerates using a circular curve.
+func EaseInCirc(t float64) float64 {
+	t = Constrain(t, 0.0, 1.0)
+	return 1.0 - math.Sqrt(1.0-math.Pow(t, 2.0))
+}
+
+// EaseOutCirc decelerates using a circular curve.
+func EaseOutCirc(t float64) float64 {
+	t = Constrain(t, 0.0, 1.0)
+	return math.Sqrt(1.0 - math.Pow(t-1.0, 2.0))
+}
+
+// EaseInOutCirc accelerates then decelerates using a circular curve.
+func EaseInOutCirc(t float64) float64 {
+	t = Constrain(t, 0.0, 1.0)
+	if t < 0.5 {
+		return (1.0 - math.Sqrt(1.0-math.Pow(2.0*t, 2.0))) / 2.0
+	}
+	return (math.Sqrt(1.0-math.Pow(-2.0*t+2.0, 2.0)) + 1.0) / 2.0
+}
+
+// EaseInBack accelerates with an initial backward overshoot.
+func EaseInBack(t float64) float64 {
+	c1 := 1.70158
+	c3 := c1 + 1.0
+	return c3*t*t*t - c1*t*t
+}
+
+// EaseOutBack decelerates with a final overshoot.
+func EaseOutBack(t float64) float64 {
+	c1 := 1.70158
+	c3 := c1 + 1.0
+	return 1.0 + c3*math.Pow(t-1.0, 3.0) + c1*math.Pow(t-1.0, 2.0)
+}
+
+// EaseInOutBack accelerates with backward overshoot then decelerates with overshoot.
+func EaseInOutBack(t float64) float64 {
+	c1 := 1.70158
+	c2 := c1 * 1.525
+	if t < 0.5 {
+		return (math.Pow(2.0*t, 2.0) * ((c2+1.0)*2.0*t - c2)) / 2.0
+	}
+	return (math.Pow(2.0*t-2.0, 2.0)*((c2+1.0)*(t*2.0-2.0)+c2) + 2.0) / 2.0
+}
+
+// EaseInElastic accelerates with an elastic bounce at the start.
+func EaseInElastic(t float64) float64 {
+	if t <= 0 {
+		return 0
+	}
+	if t >= 1.0 {
+		return 1.0
+	}
+	c4 := (2.0 * math.Pi) / 3.0
+	return -math.Pow(2.0, 10.0*t-10.0) * math.Sin((t*10.0-10.75)*c4)
+}
+
+// EaseOutElastic decelerates with an elastic bounce at the end.
+func EaseOutElastic(t float64) float64 {
+	if t <= 0 {
+		return 0
+	}
+	if t >= 1.0 {
+		return 1.0
+	}
+	c4 := (2.0 * math.Pi) / 3.0
+	return math.Pow(2.0, -10.0*t)*math.Sin((t*10.0-0.75)*c4) + 1.0
+}
+
+// EaseInOutElastic accelerates with elastic bounce, then decelerates with bounce.
+func EaseInOutElastic(t float64) float64 {
+	if t <= 0 {
+		return 0
+	}
+	if t >= 1.0 {
+		return 1.0
+	}
+	c5 := (2.0 * math.Pi) / 4.5
+	if t < 0.5 {
+		return -(math.Pow(2.0, 20.0*t-10.0) * math.Sin((20.0*t-11.125)*c5)) / 2.0
+	}
+	return (math.Pow(2.0, -20.0*t+10.0)*math.Sin((20.0*t-11.125)*c5))/2.0 + 1.0
+}
+
+// EaseOutBounce decelerates with a bouncing effect.
+func EaseOutBounce(t float64) float64 {
+	n1 := 7.5625
+	d1 := 2.75
+
+	if t < 1.0/d1 {
+		return n1 * t * t
+	} else if t < 2.0/d1 {
+		t -= 1.5 / d1
+		return n1*t*t + 0.75
+	} else if t < 2.5/d1 {
+		t -= 2.25 / d1
+		return n1*t*t + 0.9375
+	} else {
+		t -= 2.625 / d1
+		return n1*t*t + 0.984375
+	}
+}
+
+// EaseInBounce accelerates with a bouncing effect.
+func EaseInBounce(t float64) float64 {
+	return 1.0 - EaseOutBounce(1.0-t)
+}
+
+// EaseInOutBounce accelerates with bouncing then decelerates with bouncing.
+func EaseInOutBounce(t float64) float64 {
+	if t < 0.5 {
+		return (1.0 - EaseOutBounce(1.0-2.0*t)) / 2.0
+	}
+	return (1.0 + EaseOutBounce(2.0*t-1.0)) / 2.0
+}

--- a/easing_test.go
+++ b/easing_test.go
@@ -1,0 +1,64 @@
+package canvas
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEasingFunctions(t *testing.T) {
+	easingFuncs := []struct {
+		name string
+		fn   func(float64) float64
+	}{
+		{"EaseLinear", EaseLinear},
+		{"EaseInSine", EaseInSine},
+		{"EaseOutSine", EaseOutSine},
+		{"EaseInOutSine", EaseInOutSine},
+		{"EaseInQuad", EaseInQuad},
+		{"EaseOutQuad", EaseOutQuad},
+		{"EaseInOutQuad", EaseInOutQuad},
+		{"EaseInCubic", EaseInCubic},
+		{"EaseOutCubic", EaseOutCubic},
+		{"EaseInOutCubic", EaseInOutCubic},
+		{"EaseInQuart", EaseInQuart},
+		{"EaseOutQuart", EaseOutQuart},
+		{"EaseInOutQuart", EaseInOutQuart},
+		{"EaseInExpo", EaseInExpo},
+		{"EaseOutExpo", EaseOutExpo},
+		{"EaseInOutExpo", EaseInOutExpo},
+		{"EaseInCirc", EaseInCirc},
+		{"EaseOutCirc", EaseOutCirc},
+		{"EaseInOutCirc", EaseInOutCirc},
+		{"EaseInBack", EaseInBack},
+		{"EaseOutBack", EaseOutBack},
+		{"EaseInOutBack", EaseInOutBack},
+		{"EaseInElastic", EaseInElastic},
+		{"EaseOutElastic", EaseOutElastic},
+		{"EaseInOutElastic", EaseInOutElastic},
+		{"EaseInBounce", EaseInBounce},
+		{"EaseOutBounce", EaseOutBounce},
+		{"EaseInOutBounce", EaseInOutBounce},
+	}
+
+	for _, tt := range easingFuncs {
+		t.Run(tt.name, func(t *testing.T) {
+			// Boundary at t = 0
+			val0 := tt.fn(0)
+			if math.Abs(val0) > 1e-5 {
+				t.Errorf("%s(0) expected ~0, got %v", tt.name, val0)
+			}
+
+			// Boundary at t = 1
+			val1 := tt.fn(1)
+			if math.Abs(val1-1.0) > 1e-5 {
+				t.Errorf("%s(1) expected ~1, got %v", tt.name, val1)
+			}
+
+			// Midpoint check (should not be NaN or Inf)
+			valMid := tt.fn(0.5)
+			if math.IsNaN(valMid) || math.IsInf(valMid, 0) {
+				t.Errorf("%s(0.5) returned invalid value %v", tt.name, valMid)
+			}
+		})
+	}
+}

--- a/noise.go
+++ b/noise.go
@@ -124,3 +124,47 @@ func Noise2D(x, y float64) float64 {
 func Noise1D(x float64) float64 {
 	return Noise(x, 0, 0)
 }
+
+// NoiseFBM calculates 2D Fractal Brownian Motion (octave Perlin noise) normalized to [0.0, 1.0].
+// octaves is the number of noise layers (e.g. 4-8).
+// persistence controls how amplitude decreases per octave (typically ~0.5).
+// lacunarity controls how frequency increases per octave (typically ~2.0).
+func NoiseFBM(x, y float64, octaves int, persistence, lacunarity float64) float64 {
+	if octaves <= 0 {
+		return 0
+	}
+	var total, maxVal, amplitude, freq float64 = 0, 0, 1.0, 1.0
+	for i := 0; i < octaves; i++ {
+		total += Noise2D(x*freq, y*freq) * amplitude
+		maxVal += amplitude
+		amplitude *= persistence
+		freq *= lacunarity
+	}
+	if maxVal == 0 {
+		return 0
+	}
+	return Constrain(total/maxVal, 0.0, 1.0)
+}
+
+// NoiseFBM3D calculates 3D Fractal Brownian Motion (octave Perlin noise) normalized to [0.0, 1.0].
+func NoiseFBM3D(x, y, z float64, octaves int, persistence, lacunarity float64) float64 {
+	if octaves <= 0 {
+		return 0
+	}
+	var total, maxVal, amplitude, freq float64 = 0, 0, 1.0, 1.0
+	for i := 0; i < octaves; i++ {
+		total += Noise(x*freq, y*freq, z*freq) * amplitude
+		maxVal += amplitude
+		amplitude *= persistence
+		freq *= lacunarity
+	}
+	if maxVal == 0 {
+		return 0
+	}
+	return Constrain(total/maxVal, 0.0, 1.0)
+}
+
+// NoiseFBM1D calculates 1D Fractal Brownian Motion (octave Perlin noise) normalized to [0.0, 1.0].
+func NoiseFBM1D(x float64, octaves int, persistence, lacunarity float64) float64 {
+	return NoiseFBM(x, 0, octaves, persistence, lacunarity)
+}

--- a/noise_test.go
+++ b/noise_test.go
@@ -57,4 +57,29 @@ func TestNoise(t *testing.T) {
 			t.Errorf("Expected different noise output for different seeds, both were %v", val1)
 		}
 	})
+
+	t.Run("FBM Noise", func(t *testing.T) {
+		for x := 0.0; x <= 5.0; x += 0.5 {
+			for y := 0.0; y <= 5.0; y += 0.5 {
+				v2D := NoiseFBM(x, y, 4, 0.5, 2.0)
+				if v2D < 0.0 || v2D > 1.0 {
+					t.Fatalf("NoiseFBM out of bounds: %v", v2D)
+				}
+				v3D := NoiseFBM3D(x, y, 1.0, 4, 0.5, 2.0)
+				if v3D < 0.0 || v3D > 1.0 {
+					t.Fatalf("NoiseFBM3D out of bounds: %v", v3D)
+				}
+			}
+		}
+
+		v1D := NoiseFBM1D(3.5, 4, 0.5, 2.0)
+		if v1D < 0.0 || v1D > 1.0 {
+			t.Fatalf("NoiseFBM1D out of bounds: %v", v1D)
+		}
+
+		// Edge case: octaves <= 0
+		if NoiseFBM(1.0, 1.0, 0, 0.5, 2.0) != 0 {
+			t.Errorf("Expected 0 for 0 octaves")
+		}
+	})
 }


### PR DESCRIPTION
Closes #27

### Summary of Changes
- Added Fractal Brownian Motion (FBM / multi-octave noise) in `noise.go`:
  - `NoiseFBM`, `NoiseFBM3D`, `NoiseFBM1D`
- Added Robert Penner's standard animation easing functions in `easing.go`:
  - Linear, Sine, Quad, Cubic, Quart, Expo, Circ, Back, Elastic, Bounce (`In`, `Out`, `InOut`).
- Added unit tests in `noise_test.go` and `easing_test.go`.