### PR TITLE
Documentation: Expand showcase examples (Boids, Particles, Fractal Tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ func main() {
 
 Check the [examples](examples) directory for complete programs:
 
+- [`boids`](examples/boids): Craig Reynolds' flocking simulation using 2D vector arithmetic.
 - [`drawline`](examples/drawline): Interactive mouse drawing and key interactions.
 - [`flow-field`](examples/flow-field): Organic flow field particles using HSB color and Perlin noise.
+- [`fractal-tree`](examples/fractal-tree): Organic recursive fractal tree with Perlin noise wind animation.
 - [`gif-export`](examples/gif-export): Automated animated GIF recording and exporting.
 - [`lifegame`](examples/lifegame): Conway's Game of Life simulation.
 - [`noise-landscape`](examples/noise-landscape): Organic wave animation with Perlin noise.
+- [`particle-system`](examples/particle-system): Physics-based particle fountain with easings and offscreen trail layer.
 - [`rotate-objects`](examples/rotate-objects): Coordinate system rotation and object transformations.
 - [`static-art`](examples/static-art): Single-frame generative art using `NoLoop()`.
 - [`text`](examples/text): Text rendering, time tracking, and frame rate display.

--- a/examples/boids/main.go
+++ b/examples/boids/main.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"math"
+
+	"github.com/h8gi/canvas"
+)
+
+type Boid struct {
+	pos   canvas.Vec
+	vel   canvas.Vec
+	acc   canvas.Vec
+	maxS  float64
+	maxF  float64
+	hue   float64
+}
+
+func newBoid(x, y float64) *Boid {
+	angle := canvas.Random(0, math.Pi*2)
+	return &Boid{
+		pos:  canvas.V(x, y),
+		vel:  canvas.V(math.Cos(angle)*2, math.Sin(angle)*2),
+		acc:  canvas.V(0, 0),
+		maxS: 3.5,
+		maxF: 0.08,
+		hue:  canvas.Random(180, 260),
+	}
+}
+
+func (b *Boid) update(w, h float64) {
+	b.vel = canvas.VecAdd(b.vel, b.acc)
+	b.vel = canvas.VecLimit(b.vel, b.maxS)
+	b.pos = canvas.VecAdd(b.pos, b.vel)
+	b.acc = canvas.V(0, 0)
+
+	// Wrap around edges
+	if b.pos.X < 0 {
+		b.pos.X += w
+	}
+	if b.pos.X >= w {
+		b.pos.X -= w
+	}
+	if b.pos.Y < 0 {
+		b.pos.Y += h
+	}
+	if b.pos.Y >= h {
+		b.pos.Y -= h
+	}
+}
+
+func (b *Boid) applyForce(force canvas.Vec) {
+	b.acc = canvas.VecAdd(b.acc, force)
+}
+
+func (b *Boid) flock(boids []*Boid, mouse canvas.Vec, mousePressed bool) {
+	sep := b.separate(boids)
+	ali := b.align(boids)
+	coh := b.cohere(boids)
+
+	sep = canvas.VecMult(sep, 1.5)
+	ali = canvas.VecMult(ali, 1.0)
+	coh = canvas.VecMult(coh, 1.0)
+
+	b.applyForce(sep)
+	b.applyForce(ali)
+	b.applyForce(coh)
+
+	if mousePressed {
+		seekMouse := b.seek(mouse)
+		b.applyForce(canvas.VecMult(seekMouse, 2.0))
+	}
+}
+
+func (b *Boid) seek(target canvas.Vec) canvas.Vec {
+	desired := canvas.VecSub(target, b.pos)
+	desired = canvas.VecSetMag(desired, b.maxS)
+	steer := canvas.VecSub(desired, b.vel)
+	return canvas.VecLimit(steer, b.maxF)
+}
+
+func (b *Boid) separate(boids []*Boid) canvas.Vec {
+	desiredSeparation := 25.0
+	steer := canvas.V(0, 0)
+	count := 0
+
+	for _, other := range boids {
+		d := canvas.VecDist(b.pos, other.pos)
+		if d > 0 && d < desiredSeparation {
+			diff := canvas.VecSub(b.pos, other.pos)
+			diff = canvas.VecNormalize(diff)
+			diff = canvas.VecDiv(diff, d) // Closer boids have greater influence
+			steer = canvas.VecAdd(steer, diff)
+			count++
+		}
+	}
+
+	if count > 0 {
+		steer = canvas.VecDiv(steer, float64(count))
+	}
+	if canvas.VecMag(steer) > 0 {
+		steer = canvas.VecSetMag(steer, b.maxS)
+		steer = canvas.VecSub(steer, b.vel)
+		steer = canvas.VecLimit(steer, b.maxF)
+	}
+	return steer
+}
+
+func (b *Boid) align(boids []*Boid) canvas.Vec {
+	neighborDist := 50.0
+	sum := canvas.V(0, 0)
+	count := 0
+
+	for _, other := range boids {
+		d := canvas.VecDist(b.pos, other.pos)
+		if d > 0 && d < neighborDist {
+			sum = canvas.VecAdd(sum, other.vel)
+			count++
+		}
+	}
+
+	if count > 0 {
+		sum = canvas.VecDiv(sum, float64(count))
+		sum = canvas.VecSetMag(sum, b.maxS)
+		steer := canvas.VecSub(sum, b.vel)
+		return canvas.VecLimit(steer, b.maxF)
+	}
+	return canvas.V(0, 0)
+}
+
+func (b *Boid) cohere(boids []*Boid) canvas.Vec {
+	neighborDist := 50.0
+	sum := canvas.V(0, 0)
+	count := 0
+
+	for _, other := range boids {
+		d := canvas.VecDist(b.pos, other.pos)
+		if d > 0 && d < neighborDist {
+			sum = canvas.VecAdd(sum, other.pos)
+			count++
+		}
+	}
+
+	if count > 0 {
+		sum = canvas.VecDiv(sum, float64(count))
+		return b.seek(sum)
+	}
+	return canvas.V(0, 0)
+}
+
+func (b *Boid) draw(ctx *canvas.Context) {
+	angle := canvas.Heading(b.vel) + math.Pi/2
+
+	ctx.Push()
+	ctx.Translate(b.pos.X, b.pos.Y)
+	ctx.Rotate(angle)
+
+	ctx.FillHSBA(b.hue, 0.7, 0.95, 0.85)
+	ctx.StrokeHSBA(b.hue, 0.9, 1.0, 1.0)
+	ctx.SetLineWidth(1.2)
+
+	// Draw sleek triangle pointing upwards
+	ctx.DrawTriangle(0, -9, -5, 7, 5, 7)
+	ctx.Fill()
+	ctx.Stroke()
+
+	ctx.Pop()
+}
+
+func main() {
+	width, height := 800, 500
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     width,
+		Height:    height,
+		FrameRate: 60,
+		Title:     "Boids Flocking Simulation",
+	})
+
+	boids := make([]*Boid, 120)
+
+	c.Setup(func(ctx *canvas.Context) {
+		for i := 0; i < len(boids); i++ {
+			boids[i] = newBoid(canvas.Random(0, float64(width)), canvas.Random(0, float64(height)))
+		}
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		ctx.BackgroundRGB(0.06, 0.07, 0.12)
+
+		w, h := float64(ctx.Width()), float64(ctx.Height())
+		isClicked := ctx.IsMousePressed(canvas.MouseLeft)
+
+		for _, b := range boids {
+			b.flock(boids, ctx.Mouse, isClicked)
+			b.update(w, h)
+			b.draw(ctx)
+		}
+
+		ctx.FillRGB(0.7, 0.7, 0.7)
+		ctx.DrawString("Click & hold mouse to attract boids", 15, 25)
+	})
+}

--- a/examples/fractal-tree/main.go
+++ b/examples/fractal-tree/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"math"
+
+	"github.com/h8gi/canvas"
+)
+
+func branch(ctx *canvas.Context, length, thickness float64, depth int, time float64) {
+	if depth <= 0 || length < 3 {
+		// Draw a glowing flower / leaf at the tip
+		hue := math.Mod(330+float64(depth)*15, 360)
+		ctx.FillHSBA(hue, 0.7, 0.95, 0.7)
+		ctx.DrawCircle(0, 0, 4)
+		ctx.Fill()
+		return
+	}
+
+	// Calculate branch color based on depth
+	treeHue := canvas.Map(float64(depth), 0, 10, 80, 25)
+	ctx.StrokeHSBA(treeHue, 0.6, 0.8, 0.9)
+	ctx.SetLineWidth(thickness)
+
+	ctx.DrawLine(0, 0, 0, -length)
+	ctx.Stroke()
+
+	ctx.Translate(0, -length)
+
+	// Wind sway calculation with noise
+	wind := canvas.Noise1D(time*0.5+float64(depth)*0.3)*0.4 - 0.2
+	branchAngle := 0.45 + math.Sin(time*0.8)*0.05
+
+	// Right branch
+	ctx.Push()
+	ctx.Rotate(branchAngle + wind)
+	branch(ctx, length*0.72, thickness*0.7, depth-1, time)
+	ctx.Pop()
+
+	// Left branch
+	ctx.Push()
+	ctx.Rotate(-branchAngle + wind)
+	branch(ctx, length*0.72, thickness*0.7, depth-1, time)
+	ctx.Pop()
+}
+
+func main() {
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     640,
+		Height:    540,
+		FrameRate: 60,
+		Title:     "Fractal Tree with Wind Animation",
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		ctx.BackgroundRGB(0.05, 0.05, 0.09)
+
+		ctx.Push()
+		// Move origin to bottom center
+		ctx.Translate(float64(ctx.Width())/2, float64(ctx.Height())-30)
+
+		branch(ctx, 110.0, 9.0, 9, ctx.Time)
+		ctx.Pop()
+
+		ctx.FillRGB(0.7, 0.7, 0.7)
+		ctx.DrawString("Organic Fractal Tree (Perlin noise sway)", 15, 25)
+	})
+}

--- a/examples/particle-system/main.go
+++ b/examples/particle-system/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"math"
+
+	"github.com/h8gi/canvas"
+)
+
+type Particle struct {
+	pos      canvas.Vec
+	vel      canvas.Vec
+	acc      canvas.Vec
+	lifespan float64
+	maxLife  float64
+	radius   float64
+	hue      float64
+}
+
+func newParticle(x, y, hue float64) *Particle {
+	angle := canvas.Random(0, math.Pi*2)
+	speed := canvas.Random(1.5, 6.0)
+	life := canvas.Random(40, 80)
+	return &Particle{
+		pos:      canvas.V(x, y),
+		vel:      canvas.V(math.Cos(angle)*speed, math.Sin(angle)*speed-2.0),
+		acc:      canvas.V(0, 0.08), // gravity
+		lifespan: life,
+		maxLife:  life,
+		radius:   canvas.Random(3, 8),
+		hue:      hue,
+	}
+}
+
+func (p *Particle) update() {
+	p.vel = canvas.VecAdd(p.vel, p.acc)
+	p.vel = canvas.VecMult(p.vel, 0.98) // air drag
+	p.pos = canvas.VecAdd(p.pos, p.vel)
+	p.lifespan--
+}
+
+func (p *Particle) isDead() bool {
+	return p.lifespan <= 0
+}
+
+func (p *Particle) draw(ctx *canvas.Context) {
+	normLife := p.lifespan / p.maxLife
+	alpha := canvas.EaseOutQuad(normLife)
+	r := p.radius * canvas.EaseOutCubic(normLife)
+
+	ctx.FillHSBA(p.hue, 0.85, 1.0, alpha*0.8)
+	ctx.DrawCircle(p.pos.X, p.pos.Y, r)
+	ctx.Fill()
+}
+
+func main() {
+	c := canvas.NewCanvas(&canvas.CanvasConfig{
+		Width:     700,
+		Height:    500,
+		FrameRate: 60,
+		Title:     "Interactive Particle Fountain",
+	})
+
+	var particles []*Particle
+	baseHue := 0.0
+	var trailLayer *canvas.Context
+
+	c.Setup(func(ctx *canvas.Context) {
+		trailLayer = canvas.CreateGraphics(ctx.Width(), ctx.Height())
+		trailLayer.BackgroundRGB(0.04, 0.04, 0.08)
+	})
+
+	c.Draw(func(ctx *canvas.Context) {
+		baseHue = math.Mod(baseHue+0.5, 360)
+
+		// Fade previous frame on trail layer
+		trailLayer.BackgroundRGBA(0.04, 0.04, 0.08, 0.15)
+
+		// Spawn new particles from mouse or center
+		spawnPos := ctx.Mouse
+		if spawnPos.X == 0 && spawnPos.Y == 0 {
+			spawnPos = canvas.V(float64(ctx.Width())/2, float64(ctx.Height())/2)
+		}
+
+		spawnCount := 5
+		if ctx.IsMouseDragged {
+			spawnCount = 15
+		}
+
+		for i := 0; i < spawnCount; i++ {
+			hue := math.Mod(baseHue+canvas.Random(-30, 30), 360)
+			particles = append(particles, newParticle(spawnPos.X, spawnPos.Y, hue))
+		}
+
+		// Update and draw particles on trail layer
+		active := particles[:0]
+		for _, p := range particles {
+			p.update()
+			if !p.isDead() {
+				p.draw(trailLayer)
+				active = append(active, p)
+			}
+		}
+		particles = active
+
+		// Blit trail layer onto main window context
+		ctx.DrawGraphics(trailLayer, 0, 0)
+
+		ctx.FillRGB(0.8, 0.8, 0.8)
+		ctx.DrawString("Move mouse to emit particles, drag to erupt", 15, 25)
+	})
+}


### PR DESCRIPTION
Closes #31

### Summary of Changes
- Added `examples/boids`: Craig Reynolds' flocking simulation using 2D vector arithmetic and mouse attraction.
- Added `examples/particle-system`: Physics-based particle fountain with quadratic/cubic easings and offscreen trail layer.
- Added `examples/fractal-tree`: Organic recursive branching tree animated with 1D Perlin noise wind sway.
- Updated `README.md` with links to all new examples.